### PR TITLE
DOC: add issue and PR templates, zenodo.json, contributing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+or
+
+```
+# test code here
+```
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Version [e.g. 22]
+ - Other details about your setup that could be relevant
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+# Description
+
+Addresses # (issue)
+
+Please include a summary of the change and which issue is fixed. Please also
+include relevant motivation and context. List any dependencies that are required
+for this change.  Please see ``CONTRIBUTING.md`` for more guidelines.
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality
+      to not work as expected)
+- This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide
+instructions so we can reproduce. Please also list any relevant details for
+your test configuration
+
+- Test A
+- Test B
+
+**Test Configuration**:
+* Operating system
+* Version number
+* Any details about your local setup that are relevant
+
+# Checklist:
+
+- [ ] Make sure you are merging into the ``develop`` (not ``master``) branch
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,3 +42,4 @@ your test configuration
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
 - [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
+- [ ] Update zenodo.json file for new code contributors

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,31 @@
+{
+    "creators": [
+      {
+        "affiliation": "Goddard Space Flight Center",
+        "name": "Jeff Klenzing",
+        "orcid": "0000-0001-8321-6074"
+      },
+      {
+        "affiliation": "University of Texas at Dallas",
+        "name": "Russell Stoneback",
+        "orcid": "0000-0001-7216-4336"
+      },
+      {
+        "affiliation": "U.S. Naval Research Laboratory",
+        "name": "Angeline Burrell",
+        "orcid": "0000-0001-8875-9326"
+      },
+      {
+        "name": "Asher Pembroke"
+      },
+      {
+        "name": "Carey Spence",
+        "orcid": "0000-0001-8340-5625"
+      }
+    ],
+    "access_right": "open",
+    "resource_type": {
+      "type": "software",
+      "title": "Software"
+    }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+Contributing
+============
+
+Bug reports, feature suggestions and other contributions are greatly
+appreciated!  Pysat is a community-driven project and welcomes both feedback and
+contributions.
+
+Short version
+-------------
+
+* Submit bug reports and feature requests at `GitHub <https://github.com/pysat/pysatNASA/issues>`_
+* Make pull requests to the ``develop`` branch
+
+Bug reports
+-----------
+
+When `reporting a bug <https://github.com/pysat/pysatNASA/issues>`_ please
+include:
+
+* Your operating system name and version
+* Any details about your local setup that might be helpful in troubleshooting
+* Detailed steps to reproduce the bug
+
+Feature requests and feedback
+-----------------------------
+
+The best way to send feedback is to file an issue at
+`GitHub <https://github.com/pysat/pysatNASA/issues>`_.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that code contributions
+  are welcome :)
+
+Development
+-----------
+
+To set up `pysatNASA` for local development:
+
+1. `Fork pysatNASA on GitHub <https://github.com/pysat/pysatNASA/fork>`_.
+2. Clone your fork locally::
+
+    git clone git@github.com:your_name_here/pysatNASA.git
+
+3. Create a branch for local development::
+
+    git checkout -b name-of-your-bugfix-or-feature
+
+   Now you can make your changes locally. Tests for new instruments are
+   performed automatically.  Tests for custom functions should be added to the
+   appropriately named file in ``pysatNASA/tests``.  For example, custom functions
+   for the OMNI HRO data are tested in ``pysatNASA/tests/test_omni_hro.py``.  If
+   no test file exists, then you should create one.  This testing uses pytest,
+   which will run tests on any python file in the test directory that starts
+   with ``test``.  Classes must begin with ``Test``, and methods must begin
+   with ``test`` as well.
+
+4. When you're done making changes, run all the checks to ensure that nothing
+   is broken on your local system, as well as check for flake8 compliance::
+
+    pytest -vs --flake8 pysatNASA
+
+5. Update/add documentation (in ``docs``), if relevant
+
+6. Add your name to the .zenodo.json file as an author
+
+7. Commit your changes and push your branch to GitHub::
+
+    git add .
+    git commit -m "Brief description of your changes"
+    git push origin name-of-your-bugfix-or-feature
+
+8. Submit a pull request through the GitHub website. Pull requests should be
+   made to the ``develop`` branch.
+
+Pull Request Guidelines
+-----------------------
+
+If you need some code review or feedback while you're developing the code, just
+make a pull request. Pull requests should be made to the ``develop`` branch.
+
+For merging, you should:
+
+1. Include an example for use
+2. Add a note to ``CHANGELOG.md`` about the changes
+3. Ensure that all checks passed (current checks include Travis-CI (pytest and flake8)
+   and Coveralls) [1]_
+
+.. [1] If you don't have all the necessary Python versions available locally or
+       have trouble building all the testing environments, you can rely on
+       Travis to run the tests for each change you add in the pull request.
+       Because testing here will delay tests by other developers, please ensure
+       that the code passes all tests on your local system first.


### PR DESCRIPTION
Addresses #5 

Adds github templates for issues and pull requests.  Based on the versions at pysat, with a few additions for the examples.