### PR TITLE
MAINT: instrument test updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+Contributing
+============
+
+Bug reports, feature suggestions and other contributions are greatly
+appreciated!  Pysat is a community-driven project and welcomes both feedback and
+contributions.
+
+Short version
+-------------
+
+* Submit bug reports and feature requests at `GitHub <https://github.com/pysat/pysatNASA/issues>`_
+* Make pull requests to the ``develop`` branch
+
+Bug reports
+-----------
+
+When `reporting a bug <https://github.com/pysat/pysatNASA/issues>`_ please
+include:
+
+* Your operating system name and version
+* Any details about your local setup that might be helpful in troubleshooting
+* Detailed steps to reproduce the bug
+
+Feature requests and feedback
+-----------------------------
+
+The best way to send feedback is to file an issue at
+`GitHub <https://github.com/pysat/pysatNASA/issues>`_.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that code contributions
+  are welcome :)
+
+Development
+-----------
+
+To set up `pysatNASA` for local development:
+
+1. `Fork pysatNASA on GitHub <https://github.com/pysat/pysatNASA/fork>`_.
+2. Clone your fork locally::
+
+    git clone git@github.com:your_name_here/pysatNASA.git
+
+3. Create a branch for local development::
+
+    git checkout -b name-of-your-bugfix-or-feature
+
+   Now you can make your changes locally. Tests for new instruments are
+   performed automatically.  Tests for custom functions should be added to the
+   appropriately named file in ``pysatNASA/tests``.  For example, custom functions
+   for the OMNI HRO data are tested in ``pysatNASA/tests/test_omni_hro.py``.  If
+   no test file exists, then you should create one.  This testing uses pytest,
+   which will run tests on any python file in the test directory that starts
+   with ``test``.  Classes must begin with ``Test``, and methods must begin
+   with ``test`` as well.
+
+4. When you're done making changes, run all the checks to ensure that nothing
+   is broken on your local system, as well as check for flake8 compliance::
+
+    pytest -vs --flake8 pysatNASA
+
+5. Update/add documentation (in ``docs``), if relevant
+
+6. Add your name to the .zenodo.json file as an author
+
+7. Commit your changes and push your branch to GitHub::
+
+    git add .
+    git commit -m "Brief description of your changes"
+    git push origin name-of-your-bugfix-or-feature
+
+8. Submit a pull request through the GitHub website. Pull requests should be
+   made to the ``develop`` branch.
+
+Pull Request Guidelines
+-----------------------
+
+If you need some code review or feedback while you're developing the code, just
+make a pull request. Pull requests should be made to the ``develop`` branch.
+
+For merging, you should:
+
+1. Include an example for use
+2. Add a note to ``CHANGELOG.md`` about the changes
+3. Ensure that all checks passed (current checks include Travis-CI (pytest and flake8)
+   and Coveralls) [1]_
+
+.. [1] If you don't have all the necessary Python versions available locally or
+       have trouble building all the testing environments, you can rely on
+       Travis to run the tests for each change you add in the pull request.
+       Because testing here will delay tests by other developers, please ensure
+       that the code passes all tests on your local system first.

--- a/pysatNASA/tests/test_instruments.py
+++ b/pysatNASA/tests/test_instruments.py
@@ -24,7 +24,7 @@ for method in method_list:
                  for j in range(0, Nargs)]
         # Add instruments from your library
         if 'all_inst' in names:
-            mark = pytest.mark.parametrize("name", instruments['names'])
+            mark = pytest.mark.parametrize("inst_name", instruments['names'])
             getattr(InstTestClass, method).pytestmark.append(mark)
         elif 'download' in names:
             mark = pytest.mark.parametrize("inst_dict", instruments['download'])

--- a/pysatNASA/tests/test_instruments.py
+++ b/pysatNASA/tests/test_instruments.py
@@ -1,10 +1,14 @@
+import tempfile
+
 import pytest
 
+import pysat
 # Make sure to import your instrument library here
 import pysatNASA
 # Import the test classes from pysat
-from pysat.tests.instrument_test_class import generate_instrument_list
+from pysat.utils import generate_instrument_list
 from pysat.tests.instrument_test_class import InstTestClass
+
 
 # Developers for instrument libraries should update the following line to
 # point to their own library package
@@ -37,13 +41,26 @@ for method in method_list:
 
 class TestInstruments(InstTestClass):
 
-    def setup(self):
-        """Runs before every method to create a clean testing setup."""
+    def setup_class(self):
+        """Runs once before the tests to initialize the testing setup."""
+        # Make sure to use a temporary directory so that the user's setup is not
+        # altered
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.saved_path = pysat.data_dir
+        pysat.utils.set_data_dir(self.tempdir.name, store=False)
         # Developers for instrument libraries should update the following line
-        # to point to their own library package, e.g.,
+        # to point to their own subpackage location, e.g.,
         # self.inst_loc = mypackage.instruments
         self.inst_loc = pysatNASA.instruments
 
-    def teardown(self):
+    def teardown_class(self):
         """Runs after every method to clean up previous testing."""
-        del self.inst_loc
+        pysat.utils.set_data_dir(self.saved_path, store=False)
+        self.tempdir.cleanup()
+        del self.inst_loc, self.saved_path, self.tempdir
+
+    def setup_method(self):
+        """Runs before every method to create a clean testing setup."""
+
+    def teardown_method(self):
+        """Runs after every method to clean up previous testing."""

--- a/pysatNASA/tests/test_instruments.py
+++ b/pysatNASA/tests/test_instruments.py
@@ -9,8 +9,8 @@ from pysat.tests.instrument_test_class import InstTestClass
 # Developers for instrument libraries should update the following line to
 # point to their own library package
 # e.g.,
-# instruments = generate_instrument_list(package=mypackage.instruments)
-instruments = generate_instrument_list(package=pysatNASA.instruments)
+# instruments = generate_instrument_list(inst_loc=mypackage.instruments)
+instruments = generate_instrument_list(inst_loc=pysatNASA.instruments)
 
 # The following lines apply the custom instrument lists to each type of test
 method_list = [func for func in dir(InstTestClass)
@@ -27,10 +27,11 @@ for method in method_list:
             mark = pytest.mark.parametrize("name", instruments['names'])
             getattr(InstTestClass, method).pytestmark.append(mark)
         elif 'download' in names:
-            mark = pytest.mark.parametrize("inst", instruments['download'])
+            mark = pytest.mark.parametrize("inst_dict", instruments['download'])
             getattr(InstTestClass, method).pytestmark.append(mark)
         elif 'no_download' in names:
-            mark = pytest.mark.parametrize("inst", instruments['no_download'])
+            mark = pytest.mark.parametrize("inst_dict",
+                                           instruments['no_download'])
             getattr(InstTestClass, method).pytestmark.append(mark)
 
 
@@ -40,9 +41,9 @@ class TestInstruments(InstTestClass):
         """Runs before every method to create a clean testing setup."""
         # Developers for instrument libraries should update the following line
         # to point to their own library package, e.g.,
-        # self.package = mypackage.instruments
-        self.package = pysatNASA.instruments
+        # self.inst_loc = mypackage.instruments
+        self.inst_loc = pysatNASA.instruments
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.package
+        del self.inst_loc


### PR DESCRIPTION
Updates syntax for instrument tests inherited from `pysat` as part of pysat/pysat#552.
- End-to-end instrument tests now iterate over a list of `dict` objects containing info to create an instrument
- `pytest.mark` statements updated accordingly
- `package` renamed as `inst_loc`

Currently failing on Travis since these updates are not in `pysat` develop-3, but passes locally when using the tst/inst_test_class_update branch of `pysat` (with the exception of known ftp issues, ie, #8).