### PR TITLE
MAINT: update sat_id to inst_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The instrument modules are portable and designed to be run like any pysat instru
 import pysat
 from pysatNASA.instruments import icon_ivm
 
-ivm = pysat.Instrument(inst_module=icon_ivm, sat_id='a')
+ivm = pysat.Instrument(inst_module=icon_ivm, inst_id='a')
 ```
 Another way to use the instruments in an external repository is to register the instruments.  This only needs to be done the first time you load an instrument.  Afterward, pysat will identify them using the `platform` and `name` keywords.
 
@@ -46,5 +46,5 @@ Another way to use the instruments in an external repository is to register the 
 import pysat
 
 pysat.utils.registry.register('pysatNASA.instruments.icon_ivm')
-ivm = pysat.Instrument('icon', 'ivm', sat_id='a')
+ivm = pysat.Instrument('icon', 'ivm', inst_id='a')
 ```

--- a/pysatNASA/constellations/icon.py
+++ b/pysatNASA/constellations/icon.py
@@ -4,16 +4,16 @@ Creates a constellation from NASA ICON instrumentation
 """
 
 # FIXME: syntax has changed since this was written.  Not imported
-ivm = pysat.Instrument('icon', 'ivm', sat_id='a', tag='level_2',
+ivm = pysat.Instrument('icon', 'ivm', inst_id='a', tag='level_2',
                        clean_level='clean', update_files=True)
-euv = pysat.Instrument('icon', 'euv', sat_id='', tag='level_2',
+euv = pysat.Instrument('icon', 'euv', inst_id='', tag='level_2',
                        clean_level='clean', update_files=True)
-fuv = pysat.Instrument('icon', 'fuv', sat_id='', tag='level_2',
+fuv = pysat.Instrument('icon', 'fuv', inst_id='', tag='level_2',
                        clean_level='clean', update_files=True)
-mighti_green = pysat.Instrument('icon', 'mighti', sat_id='green',
+mighti_green = pysat.Instrument('icon', 'mighti', inst_id='green',
                                 tag='level_2', clean_level='clean',
                                 update_files=True)
-mighti_red = pysat.Instrument('icon', 'mighti', sat_id='red', tag='level_2',
+mighti_red = pysat.Instrument('icon', 'mighti', inst_id='red', tag='level_2',
                               clean_level='clean', update_files=True)
 
 instruments = [ivm, euv, fuv, mighti_green, mighti_red]

--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -40,7 +40,7 @@ name
     'ivm'
 tag
     None supported
-sat_id
+inst_id
     None supported
 
 Warnings
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 platform = 'cnofs'
 name = 'ivm'
 tags = {'': ''}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -42,7 +42,7 @@ name
     'plp'
 tag
     None supported
-sat_id
+inst_id
     None supported
 
 
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
 platform = 'cnofs'
 name = 'plp'
 tags = {'': ''}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -39,7 +39,7 @@ name
     'vefi'
 tag
     Select measurement type, one of {'dc_b'}
-sat_id
+inst_id
     None supported
 
 
@@ -70,7 +70,7 @@ logger = logging.getLogger(__name__)
 platform = 'cnofs'
 name = 'vefi'
 tags = {'dc_b': 'DC Magnetometer data - 1 second'}
-sat_ids = {'': ['dc_b']}
+inst_ids = {'': ['dc_b']}
 _test_dates = {'': {'dc_b': dt.datetime(2009, 1, 1)}}
 
 # support list files routine

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -36,7 +36,7 @@ platform
     'de2'
 name
     'lang'
-sat_id
+inst_id
     None Supported
 tag
     None Supported
@@ -61,7 +61,7 @@ platform = 'de2'
 name = 'lang'
 
 tags = {'': '500 ms cadence Langmuir Probe data'}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
 fname = 'de2_plasma500ms_lang_{year:04d}{month:02d}{day:02d}_v01.cdf'

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -61,7 +61,7 @@ platform
     'de2'
 name
     'nacs'
-sat_id
+inst_id
     None Supported
 tag
     None Supported
@@ -86,7 +86,7 @@ platform = 'de2'
 name = 'nacs'
 
 tags = {'': '1 s cadence Neutral Atmosphere Composition Spectrometer data'}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
 fname = 'de2_neutral1s_nacs_{year:04d}{month:02d}{day:02d}_v01.cdf'

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -46,7 +46,7 @@ platform
     'de2'
 name
     'rpa'
-sat_id
+inst_id
     None Supported
 tag
     None Supported
@@ -71,7 +71,7 @@ platform = 'de2'
 name = 'rpa'
 
 tags = {'': '2 sec cadence RPA data'}  # this is the default
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
 fname = 'de2_ion2s_rpa_{year:04d}{month:02d}{day:02d}_v01.cdf'

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -57,7 +57,7 @@ platform
     'de2'
 name
     'wats'
-sat_id
+inst_id
     None Supported
 tag
     None Supported
@@ -82,7 +82,7 @@ platform = 'de2'
 name = 'wats'
 
 tags = {'': '2 s cadence Wind and Temperature Spectrometer data'}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
 fname = 'de2_wind2s_wats_{year:04d}{month:02d}{day:02d}_v01.cdf'

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 platform = 'icon'
 name = 'euv'
 tags = {'': 'Level 2 public geophysical data'}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2020, 1, 1)}}
 _test_download_travis = {'': {kk: False for kk in tags.keys()}}
 pandas_format = False
@@ -115,7 +115,7 @@ def default(inst):
         mm_gen.remove_leading_text(inst, target='ICON_L26_')
 
 
-def load(fnames, tag=None, sat_id=None, keep_original_names=False):
+def load(fnames, tag=None, inst_id=None, keep_original_names=False):
     """Loads ICON EUV data using pysat into pandas.
 
     This routine is called as needed by pysat. It is not intended
@@ -129,7 +129,7 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     tag : string
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string
+    inst_id : string
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     keep_original_names : boolean
@@ -154,7 +154,7 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     --------
     ::
 
-        inst = pysat.Instrument('icon', 'euv', sat_id='a', tag='')
+        inst = pysat.Instrument('icon', 'euv', inst_id='a', tag='')
         inst.load(2020, 1)
 
     """

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -58,7 +58,7 @@ platform = 'icon'
 name = 'fuv'
 tags = {'day': 'Level 2 daytime O/N2',
         'night': 'Level 2 nighttime O profile'}
-sat_ids = {'': ['day', 'night']}
+inst_ids = {'': ['day', 'night']}
 _test_dates = {'': {kk: dt.datetime(2020, 1, 1) for kk in tags.keys()}}
 _test_download_travis = {'': {kk: False for kk in tags.keys()}}
 pandas_format = False
@@ -134,7 +134,7 @@ def remove_preamble(inst):
     mm_gen.remove_leading_text(inst, target=target[inst.tag])
 
 
-def load(fnames, tag=None, sat_id=None, keep_original_names=False):
+def load(fnames, tag=None, inst_id=None, keep_original_names=False):
     """Loads ICON FUV data using pysat into pandas.
 
     This routine is called as needed by pysat. It is not intended
@@ -148,7 +148,7 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     tag : string
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string
+    inst_id : string
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     keep_original_names : boolean

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -58,7 +58,7 @@ tags = {'': 'Level 2 public geophysical data'}
 # is not available as of Jun 26 2020, as this mode has not yet been engaged.
 # Bypassing tests and warning checks via the password_req flag
 inst_ids = {'a': [''],
-           'b': ['']}
+            'b': ['']}
 _test_dates = {'a': {'': dt.datetime(2020, 1, 1)},
                'b': {'': dt.datetime(2020, 1, 1)}}  # IVM-B not yet engaged
 _test_download_travis = {'a': {kk: False for kk in tags.keys()}}

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -11,7 +11,7 @@ name
     'ivm'
 tag
     None supported
-sat_id
+inst_id
     'a' or 'b'
 
 Example
@@ -19,7 +19,7 @@ Example
 ::
 
     import pysat
-    ivm = pysat.Instrument(platform='icon', name='ivm', sat_id='a')
+    ivm = pysat.Instrument(platform='icon', name='ivm', inst_id='a')
     ivm.download(dt.datetime(2020, 1, 1), dt.datetime(2020, 1, 31))
     ivm.load(2020, 1)
 
@@ -27,7 +27,7 @@ By default, pysat removes the ICON level tags from variable names, ie,
 ICON_L27_Ion_Density becomes Ion_Density.  To retain the original names, use
 ::
 
-    ivm = pysat.Instrument(platform='icon', name='ivm', sat_id='a',
+    ivm = pysat.Instrument(platform='icon', name='ivm', inst_id='a',
                            keep_original_names=True)
 
 Author
@@ -57,7 +57,7 @@ tags = {'': 'Level 2 public geophysical data'}
 # northward, and IVM-B when the remote instruments face southward. IVM-B data
 # is not available as of Jun 26 2020, as this mode has not yet been engaged.
 # Bypassing tests and warning checks via the password_req flag
-sat_ids = {'a': [''],
+inst_ids = {'a': [''],
            'b': ['']}
 _test_dates = {'a': {'': dt.datetime(2020, 1, 1)},
                'b': {'': dt.datetime(2020, 1, 1)}}  # IVM-B not yet engaged
@@ -126,7 +126,7 @@ def default(inst):
         mm_gen.remove_leading_text(inst, target='ICON_L27_')
 
 
-def load(fnames, tag=None, sat_id=None, keep_original_names=False):
+def load(fnames, tag=None, inst_id=None, keep_original_names=False):
     """Loads ICON IVM data using pysat into pandas.
 
     This routine is called as needed by pysat. It is not intended
@@ -140,7 +140,7 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     tag : string
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string
+    inst_id : string
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     keep_original_names : boolean
@@ -162,7 +162,7 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     --------
     ::
 
-        inst = pysat.Instrument('icon', 'ivm', sat_id='a', tag='')
+        inst = pysat.Instrument('icon', 'ivm', inst_id='a', tag='')
         inst.load(2020, 1)
 
     """

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -310,11 +310,10 @@ def clean(inst):
         saa_flag = 'Quality_Flag_South_Atlantic_Anomaly'
         cal_flag = 'Quality_Flag_Bad_Calibration'
         if saa_flag not in inst.variables:
-            saa_flag = '_'.join(('ICON_L1_MIGHTI', inst.inst_id.upper(),
-                                 saa_flag))
-            cal_flag = '_'.join(('ICON_L1_MIGHTI', inst.inst_id.upper(),
-                                 cal_flag))
-            var = '_'.join(('ICON_L23_MIGHTI', inst.inst_id.upper(), var))
+            id_str = inst.inst_id.upper()
+            saa_flag = '_'.join(('ICON_L1_MIGHTI', id_str, saa_flag))
+            cal_flag = '_'.join(('ICON_L1_MIGHTI', id_str, cal_flag))
+            var = '_'.join(('ICON_L23_MIGHTI', id_str, var))
         if inst.clean_level in ['clean', 'dusty']:
             # filter out areas with bad calibration data
             # as well as data marked in the SAA

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -13,8 +13,8 @@ name
 tag
     Supports 'los_wind_green', 'los_wind_red', 'vector_wind_green',
     'vector_wind_red', 'temperature'.  Note that not every data product
-    available for every sat_id
-sat_id
+    available for every inst_id
+inst_id
     '', 'a', or 'b'
 
 Warnings
@@ -67,13 +67,13 @@ tags = {'los_wind_green': 'Line of sight wind data -- Green Line',
         'vector_wind_green': 'Vector wind data -- Green Line',
         'vector_wind_red': 'Vector wind data -- Red Line',
         'temperature': 'Neutral temperature data'}
-sat_ids = {'': ['vector_wind_green', 'vector_wind_red'],
+inst_ids = {'': ['vector_wind_green', 'vector_wind_red'],
            'a': ['los_wind_green', 'los_wind_red', 'temperature'],
            'b': ['los_wind_green', 'los_wind_red', 'temperature']}
-_test_dates = {jj: {kk: dt.datetime(2020, 1, 2) for kk in sat_ids[jj]}
-               for jj in sat_ids.keys()}
-_test_download_travis = {jj: {kk: False for kk in sat_ids[jj]}
-                         for jj in sat_ids.keys()}
+_test_dates = {jj: {kk: dt.datetime(2020, 1, 2) for kk in inst_ids[jj]}
+               for jj in inst_ids.keys()}
+_test_download_travis = {jj: {kk: False for kk in inst_ids[jj]}
+                         for jj in inst_ids.keys()}
 pandas_format = False
 
 datestr = '{year:04d}-{month:02d}-{day:02d}_v{version:02d}r{revision:03d}'
@@ -172,15 +172,15 @@ def remove_preamble(inst):
               'los_wind_red': 'ICON_L21_',
               'vector_wind_green': 'ICON_L22_',
               'vector_wind_red': 'ICON_L22_',
-              'temperature': ['ICON_L1_MIGHTI_{}_'.format(inst.sat_id.upper()),
-                              'ICON_L23_MIGHTI_{}_'.format(inst.sat_id.upper()),
+              'temperature': ['ICON_L1_MIGHTI_{}_'.format(inst.inst_id.upper()),
+                              'ICON_L23_MIGHTI_{}_'.format(inst.inst_id.upper()),
                               'ICON_L23_']}
     mm_gen.remove_leading_text(inst, target=target[inst.tag])
 
     return
 
 
-def load(fnames, tag=None, sat_id=None, keep_original_names=False):
+def load(fnames, tag=None, inst_id=None, keep_original_names=False):
     """Loads ICON FUV data using pysat into pandas.
 
     This routine is called as needed by pysat. It is not intended
@@ -194,7 +194,7 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     tag : string
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string
+    inst_id : string
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     keep_original_names : boolean
@@ -309,11 +309,11 @@ def clean(inst):
         saa_flag = 'Quality_Flag_South_Atlantic_Anomaly'
         cal_flag = 'Quality_Flag_Bad_Calibration'
         if saa_flag not in inst.variables:
-            saa_flag = '_'.join(('ICON_L1_MIGHTI', inst.sat_id.upper(),
+            saa_flag = '_'.join(('ICON_L1_MIGHTI', inst.inst_id.upper(),
                                  saa_flag))
-            cal_flag = '_'.join(('ICON_L1_MIGHTI', inst.sat_id.upper(),
+            cal_flag = '_'.join(('ICON_L1_MIGHTI', inst.inst_id.upper(),
                                  cal_flag))
-            var = '_'.join(('ICON_L23_MIGHTI', inst.sat_id.upper(), var))
+            var = '_'.join(('ICON_L23_MIGHTI', inst.inst_id.upper(), var))
         if inst.clean_level in ['clean', 'dusty']:
             # filter out areas with bad calibration data
             # as well as data marked in the SAA

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -68,8 +68,8 @@ tags = {'los_wind_green': 'Line of sight wind data -- Green Line',
         'vector_wind_red': 'Vector wind data -- Red Line',
         'temperature': 'Neutral temperature data'}
 inst_ids = {'': ['vector_wind_green', 'vector_wind_red'],
-           'a': ['los_wind_green', 'los_wind_red', 'temperature'],
-           'b': ['los_wind_green', 'los_wind_red', 'temperature']}
+            'a': ['los_wind_green', 'los_wind_red', 'temperature'],
+            'b': ['los_wind_green', 'los_wind_red', 'temperature']}
 _test_dates = {jj: {kk: dt.datetime(2020, 1, 2) for kk in inst_ids[jj]}
                for jj in inst_ids.keys()}
 _test_download_travis = {jj: {kk: False for kk in inst_ids[jj]}

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -167,13 +167,14 @@ def default(inst):
 
 def remove_preamble(inst):
     """Removes preambles in variable names"""
+    id_str = inst.inst_id.upper()
 
     target = {'los_wind_green': 'ICON_L21_',
               'los_wind_red': 'ICON_L21_',
               'vector_wind_green': 'ICON_L22_',
               'vector_wind_red': 'ICON_L22_',
-              'temperature': ['ICON_L1_MIGHTI_{}_'.format(inst.inst_id.upper()),
-                              'ICON_L23_MIGHTI_{}_'.format(inst.inst_id.upper()),
+              'temperature': ['ICON_L1_MIGHTI_{}_'.format(id_str),
+                              'ICON_L23_MIGHTI_{}_'.format(id_str),
                               'ICON_L23_']}
     mm_gen.remove_leading_text(inst, target=target[inst.tag])
 

--- a/pysatNASA/instruments/iss_fpmu.py
+++ b/pysatNASA/instruments/iss_fpmu.py
@@ -12,7 +12,7 @@ name
     'fpmu'
 tag
     None Supported
-sat_id
+inst_id
     None supported
 
 Warnings
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 platform = 'iss'
 name = 'fpmu'
 tags = {'': ''}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2017, 10, 1)}}
 
 # support list files routine

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -19,7 +19,7 @@ from pysat.utils import files as futils
 logger = logging.getLogger(__name__)
 
 
-def load(fnames, tag=None, sat_id=None,
+def load(fnames, tag=None, inst_id=None,
          fake_daily_files_from_monthly=False,
          flatten_twod=True):
     """Load NASA CDAWeb CDF files.
@@ -33,7 +33,7 @@ def load(fnames, tag=None, sat_id=None,
         Series of filenames
     tag : str or NoneType
         tag or None (default=None)
-    sat_id : str or NoneType
+    inst_id : str or NoneType
         satellite id or None (default=None)
     fake_daily_files_from_monthly : bool
         Some CDAWeb instrument data files are stored by month, interfering
@@ -96,7 +96,7 @@ def load(fnames, tag=None, sat_id=None,
                 return cdf.to_pysat(flatten_twod=flatten_twod)
 
 
-def download(supported_tags, date_array, tag, sat_id,
+def download(supported_tags, date_array, tag, inst_id,
              remote_site='https://cdaweb.gsfc.nasa.gov',
              data_path=None, user=None, password=None,
              fake_daily_files_from_monthly=False,
@@ -116,7 +116,7 @@ def download(supported_tags, date_array, tag, sat_id,
         Array of datetimes to download data for. Provided by pysat.
     tag : str or NoneType
         tag or None (default=None)
-    sat_id : (str or NoneType)
+    inst_id : (str or NoneType)
         satellite id or None (default=None)
     remote_site : string or NoneType
         Remote site to download data from
@@ -154,9 +154,9 @@ def download(supported_tags, date_array, tag, sat_id,
     """
 
     try:
-        inst_dict = supported_tags[sat_id][tag]
+        inst_dict = supported_tags[inst_id][tag]
     except KeyError:
-        raise ValueError('sat_id / tag combo unknown.')
+        raise ValueError('inst_id / tag combo unknown.')
 
     # path to relevant file on CDAWeb
     remote_url = remote_site + inst_dict['dir']
@@ -171,7 +171,7 @@ def download(supported_tags, date_array, tag, sat_id,
 
     if not multi_file_day:
         # Get list of files from server
-        remote_files = list_remote_files(tag=tag, sat_id=sat_id,
+        remote_files = list_remote_files(tag=tag, inst_id=inst_id,
                                          remote_site=remote_site,
                                          supported_tags=supported_tags,
                                          start=date_array[0],
@@ -221,7 +221,7 @@ def download(supported_tags, date_array, tag, sat_id,
                 logger.info(' '.join(('Attempting to download files for',
                                       date.strftime('%d %B %Y'))))
                 sys.stdout.flush()
-                remote_files = list_remote_files(tag=tag, sat_id=sat_id,
+                remote_files = list_remote_files(tag=tag, inst_id=inst_id,
                                                  remote_site=remote_site,
                                                  supported_tags=supported_tags,
                                                  start=date,
@@ -249,7 +249,7 @@ def download(supported_tags, date_array, tag, sat_id,
                                       date.strftime('%d %B %Y'))))
 
 
-def list_remote_files(tag, sat_id,
+def list_remote_files(tag, inst_id,
                       remote_site='https://cdaweb.gsfc.nasa.gov',
                       supported_tags=None,
                       user=None, password=None,
@@ -266,7 +266,7 @@ def list_remote_files(tag, sat_id,
     tag : string or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.
         (default=None)
     remote_site : string or NoneType
@@ -329,12 +329,12 @@ def list_remote_files(tag, sat_id,
 
     if tag is None:
         tag = ''
-    if sat_id is None:
-        sat_id = ''
+    if inst_id is None:
+        inst_id = ''
     try:
-        inst_dict = supported_tags[sat_id][tag]
+        inst_dict = supported_tags[inst_id][tag]
     except KeyError:
-        raise ValueError('sat_id / tag combo unknown.')
+        raise ValueError('inst_id / tag combo unknown.')
 
     # path to relevant file on CDAWeb
     remote_url = remote_site + inst_dict['dir']

--- a/pysatNASA/instruments/methods/icon.py
+++ b/pysatNASA/instruments/methods/icon.py
@@ -283,7 +283,8 @@ def ssl_download(date_array, tag, inst_id, data_path=None,
     """
 
     # get a list of remote files
-    remote_files = list_remote_files(tag, inst_id, supported_tags=supported_tags,
+    remote_files = list_remote_files(tag, inst_id,
+                                     supported_tags=supported_tags,
                                      start=date_array[0], stop=date_array[-1])
 
     # connect to CDAWeb default port

--- a/pysatNASA/instruments/methods/icon.py
+++ b/pysatNASA/instruments/methods/icon.py
@@ -109,7 +109,7 @@ refs = {'euv': ' '.join(('Stephan, A.W., Meier, R.R., England, S.L. et al.',
                              'https://doi.org/10.1007/s11214-017-0449-2\n'))}
 
 
-def list_remote_files(tag, sat_id, user=None, password=None,
+def list_remote_files(tag, inst_id, user=None, password=None,
                       supported_tags=None,
                       year=None, month=None, day=None,
                       start=None, stop=None):
@@ -121,7 +121,7 @@ def list_remote_files(tag, sat_id, user=None, password=None,
     tag : string or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     user : string or NoneType
@@ -156,9 +156,9 @@ def list_remote_files(tag, sat_id, user=None, password=None,
     ftp.login()
 
     try:
-        ftp_dict = supported_tags[sat_id][tag]
+        ftp_dict = supported_tags[inst_id][tag]
     except KeyError:
-        raise ValueError('sat_id/tag name unknown.')
+        raise ValueError('inst_id/tag name unknown.')
 
     # naming scheme for files on the CDAWeb server
     remote_fname = ftp_dict['remote_fname']
@@ -252,7 +252,7 @@ def list_remote_files(tag, sat_id, user=None, password=None,
     return output[start:stop]
 
 
-def ssl_download(date_array, tag, sat_id, data_path=None,
+def ssl_download(date_array, tag, inst_id, data_path=None,
                  user=None, password=None, supported_tags=None):
     """Download ICON data from public area of SSL ftp server
 
@@ -264,7 +264,7 @@ def ssl_download(date_array, tag, sat_id, data_path=None,
     tag : string
         Tag identifier used for particular dataset. This input is provided by
         pysat. (default='')
-    sat_id : string
+    inst_id : string
         Satellite ID string identifier used for particular dataset. This input
         is provided by pysat. (default='')
     data_path : string
@@ -283,7 +283,7 @@ def ssl_download(date_array, tag, sat_id, data_path=None,
     """
 
     # get a list of remote files
-    remote_files = list_remote_files(tag, sat_id, supported_tags=supported_tags,
+    remote_files = list_remote_files(tag, inst_id, supported_tags=supported_tags,
                                      start=date_array[0], stop=date_array[-1])
 
     # connect to CDAWeb default port

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -12,7 +12,7 @@ name
     'hro'
 tag
     Select time between samples, one of {'1min', '5min'}
-sat_id
+inst_id
     None supported
 
 Note
@@ -64,7 +64,7 @@ platform = 'omni'
 name = 'hro'
 tags = {'1min': '1-minute time averaged data',
         '5min': '5-minute time averaged data'}
-sat_ids = {'': ['5min']}
+inst_ids = {'': ['5min']}
 _test_dates = {'': {'1min': dt.datetime(2009, 1, 1),
                     '5min': dt.datetime(2009, 1, 1)}}
 

--- a/pysatNASA/instruments/rocsat1_ivm.py
+++ b/pysatNASA/instruments/rocsat1_ivm.py
@@ -11,7 +11,7 @@ name
     'ivm'
 tag
     None
-sat_id
+inst_id
     None supported
 
 Warnings
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 platform = 'rocsat1'
 name = 'ivm'
 tags = {'': ''}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2002, 1, 1)}}
 
 # support list files routine

--- a/pysatNASA/instruments/sport_ivm.py
+++ b/pysatNASA/instruments/sport_ivm.py
@@ -27,7 +27,7 @@ tags = {'': 'Level-2 IVM Files',
         'L0': 'Level-0 IVM Files'}
 # dictionary of satellite IDs, list of corresponding tags
 # only one satellite in this case
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 # good day to download test data for. Downloads aren't currently supported
 _test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
 _test_download = {'': {kk: False for kk in tags.keys()}}
@@ -57,7 +57,7 @@ def init(self):
     return
 
 
-def load(fnames, tag=None, sat_id=None, **kwargs):
+def load(fnames, tag=None, inst_id=None, **kwargs):
     """Loads SPORT IVM data using pysat.utils.load_netcdf4.
 
     This routine is called as needed by pysat. It is not intended
@@ -71,7 +71,7 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     tag : string
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string
+    inst_id : string
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     **kwargs : extra keywords
@@ -103,7 +103,7 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     return pysat.utils.load_netcdf4(fnames, **kwargs)
 
 
-def download(date_array, tag, sat_id, data_path=None, user=None,
+def download(date_array, tag, inst_id, data_path=None, user=None,
              password=None):
     """Downloads data for SPORT IVM, once SPORT is operational and in orbit.
     This routine is invoked by pysat and is not intended for direct use by
@@ -116,7 +116,7 @@ def download(date_array, tag, sat_id, data_path=None, user=None,
     tag : string ('')
         Tag identifier used for particular dataset. This input is provided by
         pysat.
-    sat_id : string  ('')
+    inst_id : string  ('')
         Satellite ID string identifier used for particular dataset. This input
         is provided by pysat.
     data_path : string (None)

--- a/pysatNASA/instruments/templates/template_cdaweb_instrument.py
+++ b/pysatNASA/instruments/templates/template_cdaweb_instrument.py
@@ -15,8 +15,8 @@ platform
     *List platform string here*
 name
     *List name string here*
-sat_id
-    *List supported sat_ids here*
+inst_id
+    *List supported inst_ids here*
 tag
     *List supported tag strings here*
 
@@ -69,12 +69,12 @@ tags = {'': 'description 1',  # this is the default
 # by these routines
 # define a dictionary keyed by satellite ID, each with a list of
 # corresponding tags
-# sat_ids = {'a':['L1', 'L0'], 'b':['L1', 'L2'], 'c':['L1', 'L3']}
-sat_ids = {'': ['']}
+# inst_ids = {'a':['L1', 'L0'], 'b':['L1', 'L2'], 'c':['L1', 'L3']}
+inst_ids = {'': ['']}
 
 # Define good days to download data for when pysat undergoes testing.
-# format is outer dictionary has sat_id as the key
-# each sat_id has a dictionary of test dates keyed by tag string
+# format is outer dictionary has inst_id as the key
+# each inst_id has a dictionary of test dates keyed by tag string
 # _test_dates = {'a':{'L0':dt.datetime(2019,1,1),
 #                     'L1':dt.datetime(2019,1,2)},
 #                'b':{'L1':dt.datetime(2019,3,1),
@@ -84,7 +84,7 @@ _test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
 # Additional information needs to be defined
 # to support the CDAWeb list files routine
 # We need to define a filename format string for every
-# supported combination of sat_id and tag string
+# supported combination of inst_id and tag string
 # fname1 = 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
 # fname2 = 'cnofs_vefi_acfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
 # supported_tags = {'sat1':{'tag1':fname1},
@@ -116,9 +116,9 @@ load = cdw.load
 # directory location on CDAWeb ftp server
 # formatting template for filenames on CDAWeb
 # formatting template for files saved to the local disk
-# a dictionary needs to be created for each sat_id and tag
+# a dictionary needs to be created for each inst_id and tag
 # combination along with the file format template
-# outer dict keyed by sat_id, inner dict keyed by tag
+# outer dict keyed by inst_id, inner dict keyed by tag
 basic_tag = {'dir': '/pub/data/cnofs/vefi/bfield_1sec',
              'remote_fname': '{year:4d}/' + fname,
              'local_fname': fname}

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -11,7 +11,7 @@ name : string
     'saber'
 tag : string
     None supported
-sat_id : string
+inst_id : string
     None supported
 
 Note
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 platform = 'timed'
 name = 'saber'
 tags = {'': ''}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
 
 fname = ''.join(('timed_l2av207_saber_{year:04d}{month:02d}{day:02d}',

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -15,7 +15,7 @@ name
     'see'
 tag
     None
-sat_id
+inst_id
     None supported
 flatten_twod
     If True, then two dimensional data is flattened across
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 platform = 'timed'
 name = 'see'
 tags = {'': ''}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 

--- a/pysatNASA/tests/test_methods_cdaweb.py
+++ b/pysatNASA/tests/test_methods_cdaweb.py
@@ -12,7 +12,7 @@ class TestCDAWeb():
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         self.supported_tags = pysatNASA.instruments.cnofs_plp.supported_tags
-        self.kwargs = {'tag': None, 'sat_id': None}
+        self.kwargs = {'tag': None, 'inst_id': None}
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
@@ -22,7 +22,7 @@ class TestCDAWeb():
         """pysat should append suggested help to ConnectionError"""
         with pytest.raises(Exception) as excinfo:
             # Giving a bad remote_site address yields similar ConnectionError
-            cdw.list_remote_files(tag='', sat_id='',
+            cdw.list_remote_files(tag='', inst_id='',
                                   supported_tags=self.supported_tags,
                                   remote_site='http:/')
 
@@ -37,9 +37,9 @@ class TestCDAWeb():
         assert meta is None
 
     @pytest.mark.parametrize("bad_key,bad_val,err_msg",
-                             [("tag", "badval", "sat_id / tag combo unknown."),
-                              ("sat_id", "badval",
-                               "sat_id / tag combo unknown.")])
+                             [("tag", "badval", "inst_id / tag combo unknown."),
+                              ("inst_id", "badval",
+                               "inst_id / tag combo unknown.")])
     def test_bad_kwarg_download(self, bad_key, bad_val, err_msg):
         date_array = [dt.datetime(2019, 1, 1)]
         self.kwargs[bad_key] = bad_val
@@ -47,17 +47,17 @@ class TestCDAWeb():
             cdw.download(supported_tags=self.supported_tags,
                          date_array=date_array,
                          tag=self.kwargs['tag'],
-                         sat_id=self.kwargs['sat_id'])
+                         inst_id=self.kwargs['inst_id'])
         assert str(excinfo.value).find(err_msg) >= 0
 
     @pytest.mark.parametrize("bad_key,bad_val,err_msg",
-                             [("tag", "badval", "sat_id / tag combo unknown."),
-                              ("sat_id", "badval",
-                               "sat_id / tag combo unknown.")])
+                             [("tag", "badval", "inst_id / tag combo unknown."),
+                              ("inst_id", "badval",
+                               "inst_id / tag combo unknown.")])
     def test_bad_kwarg_list_remote_files(self, bad_key, bad_val, err_msg):
         self.kwargs[bad_key] = bad_val
         with pytest.raises(ValueError) as excinfo:
             cdw.list_remote_files(supported_tags=self.supported_tags,
                                   tag=self.kwargs['tag'],
-                                  sat_id=self.kwargs['sat_id'])
+                                  inst_id=self.kwargs['inst_id'])
         assert str(excinfo.value).find(err_msg) >= 0

--- a/pysatNASA/tests/test_omni_hro.py
+++ b/pysatNASA/tests/test_omni_hro.py
@@ -11,7 +11,7 @@ class TestOMNICustom():
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         # Load a test instrument
-        self.testInst = pysat.Instrument('pysat', 'testing', sat_id='12',
+        self.testInst = pysat.Instrument('pysat', 'testing', inst_id='12',
                                          tag='1min', clean_level='clean')
         self.testInst.load(2009, 1)
 


### PR DESCRIPTION
Addresses pysat/pysat#473, test with pysat/pysat#556

Updates use of `sat_id` to `inst_id`.

Passing locally with the `break/inst_id` branch of pysat.  Expected to fail on Travis until pysat/pysat#556 is merged.