### PR TITLE
ENH: include support for extraction from zip files in ssl_dowload

### DIFF
--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -78,9 +78,9 @@ list_files = functools.partial(mm_gen.list_files,
 
 # support download routine
 basic_tag_a = {'dir': '/pub/LEVEL.2/IVM-A',
-               'remote_fname': 'Data/' + aname}
+               'remote_fname': ''.join(('ZIP/', aname[:-2], 'ZIP'))}
 basic_tag_b = {'dir': '/pub/LEVEL.2/IVM-B',
-               'remote_fname': 'Data/' + bname}
+               'remote_fname': ''.join(('ZIP/', bname[:-2], 'ZIP'))}
 
 download_tags = {'a': {'': basic_tag_a},
                  'b': {'': basic_tag_b}}

--- a/pysatNASA/instruments/methods/icon.py
+++ b/pysatNASA/instruments/methods/icon.py
@@ -6,6 +6,8 @@ import ftplib
 import logging
 import numpy as np
 import os
+import shutil
+from zipfile import ZipFile
 
 import pysat
 from pysat.utils import files as futils
@@ -307,6 +309,19 @@ def ssl_download(date_array, tag, inst_id, data_path=None,
                 ftp.retrbinary('RETR ' + fname,
                                open(saved_local_fname, 'wb').write)
                 logger.info('Finished.')
+                # If zipped files are stored remotely, unzip them locally and
+                # delete the downloaded zip
+                if fname.find('ZIP') > 0:
+                    with ZipFile(saved_local_fname, 'r') as zipObj:
+                        for member in zipObj.namelist():
+                            if member.find('.NC') > 0:
+                                outpath = os.path.join(data_path,
+                                                       os.path.basename(member))
+                                source = zipObj.open(member)
+                                target = open(outpath, 'wb')
+                                with source, target:
+                                    shutil.copyfileobj(source, target)
+                    os.remove(saved_local_fname)
             except ftplib.error_perm as exception:
                 if str(exception.args[0]).split(" ", 1)[0] != '550':
                     raise

--- a/pysatNASA/instruments/methods/icon.py
+++ b/pysatNASA/instruments/methods/icon.py
@@ -317,10 +317,9 @@ def ssl_download(date_array, tag, inst_id, data_path=None,
                             if member.find('.NC') > 0:
                                 outpath = os.path.join(data_path,
                                                        os.path.basename(member))
-                                source = zipObj.open(member)
-                                target = open(outpath, 'wb')
-                                with source, target:
-                                    shutil.copyfileobj(source, target)
+                                with zipObj.open(member) as source:
+                                    with open(outpath, 'wb') as target:
+                                        shutil.copyfileobj(source, target)
                     os.remove(saved_local_fname)
             except ftplib.error_perm as exception:
                 if str(exception.args[0]).split(" ", 1)[0] != '550':


### PR DESCRIPTION
Addresses #8.

ICON IVM files currently being stored as zip files on the remote data server.  This adjusts the download tags to search for zip files in the new location, while maintaining netCDF4 as the primary file name. Adds a generalized check to `icon.ssl_download` to automatically unzip zip files and pull the data out to the appropriate directory, removing the zip file afterward.

Tests are compatible with end-to-end tests if run locally (skipped on Travis CI).  The develop branch fails locally, this branch passes.

Simple test script:
```
import datetime as dt
import pysat
import pysatNASA
ivm = pysat.Instrument(inst_module=pysatNASA.instruments.icon_ivm, inst_id='a')
ivm.download(dt.datetime(2020, 2, 1), dt.datetime(2020, 2, 28))
ivm.files.files
```