### PR TITLE
STY: streamline cdaweb download, variable consistency, version support

### DIFF
--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -73,7 +73,7 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 # support list files routine
 # use the default CDAWeb method
-fname = 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+fname = 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf'
 supported_tags = {'': {'': fname}}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)

--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -86,11 +86,11 @@ load = cdw.load
 # use the default CDAWeb method
 basic_tag = {'remote_dir': '/pub/data/cnofs/cindi/ivm_500ms_cdf/{year:4d}/',
              'fname': fname}
-supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags)
+download_tags = {'': {'': basic_tag}}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 
 def init(self):

--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -87,7 +87,7 @@ load = cdw.load
 basic_tag = {'remote_dir': '/pub/data/cnofs/cindi/ivm_500ms_cdf/{year:4d}/',
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=supported_tags)

--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -84,9 +84,8 @@ load = cdw.load
 
 # support download routine
 # use the default CDAWeb method
-basic_tag = {'dir': '/pub/data/cnofs/cindi/ivm_500ms_cdf',
-             'remote_fname': '{year:4d}/' + fname,
-             'local_fname': fname}
+basic_tag = {'remote_dir': '/pub/data/cnofs/cindi/ivm_500ms_cdf/{year:4d}/',
+             'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 # support listing files currently on CDAWeb

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -87,11 +87,11 @@ load = cdw.load
 # use the default CDAWeb method
 basic_tag = {'remote_dir': '/pub/data/cnofs/plp/plasma_1sec/{year:4d}/',
              'fname': fname}
-supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags)
+download_tags = {'': {'': basic_tag}}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 
 def init(self):

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -84,9 +84,8 @@ load = cdw.load
 
 # support download routine
 # use the default CDAWeb method
-basic_tag = {'dir': '/pub/data/cnofs/plp/plasma_1sec',
-             'remote_fname': '{year:4d}/' + fname,
-             'local_fname': fname}
+basic_tag = {'remote_dir': '/pub/data/cnofs/plp/plasma_1sec/{year:4d}/',
+             'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 # support listing files currently on CDAWeb

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -74,7 +74,8 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 # support list files routine
 # use the default CDAWeb method
-fname = 'cnofs_plp_plasma_1sec_{year:04d}{month:02d}{day:02d}_v01.cdf'
+fname = ''.join(('cnofs_plp_plasma_1sec_{year:04d}{month:02d}{day:02d}',
+                 '_v{version:02d}.cdf'))
 supported_tags = {'': {'': fname}}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -88,7 +88,7 @@ load = cdw.load
 basic_tag = {'remote_dir': '/pub/data/cnofs/plp/plasma_1sec/{year:4d}/',
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=supported_tags)

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -75,7 +75,8 @@ _test_dates = {'': {'dc_b': dt.datetime(2009, 1, 1)}}
 
 # support list files routine
 # use the default CDAWeb method
-fname = 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
+fname = ''.join(('cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}',
+                 '_v{version:02d}.cdf'))
 supported_tags = {'': {'dc_b': fname}}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -88,11 +88,11 @@ load = cdw.load
 # use the default CDAWeb method
 basic_tag = {'remote_dir': '/pub/data/cnofs/vefi/bfield_1sec/{year:4d}/',
              'fname': fname}
-supported_tags = {'': {'dc_b': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags)
+download_tags = {'': {'dc_b': basic_tag}}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 
 def init(self):

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -89,7 +89,7 @@ load = cdw.load
 basic_tag = {'remote_dir': '/pub/data/cnofs/vefi/bfield_1sec/{year:4d}/',
              'fname': fname}
 supported_tags = {'': {'dc_b': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=supported_tags)

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -85,9 +85,8 @@ load = cdw.load
 
 # support download routine
 # use the default CDAWeb method
-basic_tag = {'dir': '/pub/data/cnofs/vefi/bfield_1sec',
-             'remote_fname': '{year:4d}/' + fname,
-             'local_fname': fname}
+basic_tag = {'remote_dir': '/pub/data/cnofs/vefi/bfield_1sec/{year:4d}/',
+             'fname': fname}
 supported_tags = {'': {'dc_b': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 # support listing files currently on CDAWeb

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -78,12 +78,12 @@ load = cdw.load
 basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/plasma_lang',
                                     '/plasma500ms_lang_cdaweb/{year:4d}/')),
              'fname': fname}
-supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags)
+download_tags = {'': {'': basic_tag}}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 
 def init(self):

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -64,7 +64,7 @@ tags = {'': '500 ms cadence Langmuir Probe data'}
 inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
-fname = 'de2_plasma500ms_lang_{year:04d}{month:02d}{day:02d}_v01.cdf'
+fname = 'de2_plasma500ms_lang_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf'
 supported_tags = {'': {'': fname}}
 
 # use the CDAWeb methods list files routine

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -79,7 +79,7 @@ basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/plasma_lang',
                                     '/plasma500ms_lang_cdaweb/{year:4d}/')),
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -75,9 +75,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # support download routine
-basic_tag = {'dir': '/pub/data/de/de2/plasma_lang/plasma500ms_lang_cdaweb',
-             'remote_fname': '{year:4d}/' + fname,
-             'local_fname': fname}
+basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/plasma_lang',
+                                    '/plasma500ms_lang_cdaweb/{year:4d}/')),
+             'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -103,12 +103,12 @@ load = cdw.load
 basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/neutral_gas_nacs',
                                     '/neutral1s_nacs_cdaweb/{year:4d}/')),
              'fname': fname}
-supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags)
+download_tags = {'': {'': basic_tag}}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 
 def init(self):

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -89,7 +89,7 @@ tags = {'': '1 s cadence Neutral Atmosphere Composition Spectrometer data'}
 inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
-fname = 'de2_neutral1s_nacs_{year:04d}{month:02d}{day:02d}_v01.cdf'
+fname = 'de2_neutral1s_nacs_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf'
 supported_tags = {'': {'': fname}}
 
 # use the CDAWeb methods list files routine

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -104,7 +104,7 @@ basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/neutral_gas_nacs',
                                     '/neutral1s_nacs_cdaweb/{year:4d}/')),
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -100,9 +100,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # support download routine
-basic_tag = {'dir': '/pub/data/de/de2/neutral_gas_nacs/neutral1s_nacs_cdaweb',
-             'remote_fname': '{year:4d}/' + fname,
-             'local_fname': fname}
+basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/neutral_gas_nacs',
+                                    '/neutral1s_nacs_cdaweb/{year:4d}/')),
+             'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -89,7 +89,7 @@ basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/plasma_rpa',
                                     '/ion2s_cdaweb/{year:4d}/')),
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -88,12 +88,12 @@ load = cdw.load
 basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/plasma_rpa',
                                     '/ion2s_cdaweb/{year:4d}/')),
              'fname': fname}
-supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags)
+download_tags = {'': {'': basic_tag}}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 
 def init(self):

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -74,7 +74,7 @@ tags = {'': '2 sec cadence RPA data'}  # this is the default
 inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
-fname = 'de2_ion2s_rpa_{year:04d}{month:02d}{day:02d}_v01.cdf'
+fname = 'de2_ion2s_rpa_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf'
 supported_tags = {'': {'': fname}}
 
 # use the CDAWeb methods list files routine

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -85,9 +85,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # support download routine
-basic_tag = {'dir': '/pub/data/de/de2/plasma_rpa/ion2s_cdaweb',
-             'remote_fname': '{year:4d}/' + fname,
-             'local_fname': fname}
+basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/plasma_rpa',
+                                    '/ion2s_cdaweb/{year:4d}/')),
+             'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -96,9 +96,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # support download routine
-basic_tag = {'dir': '/pub/data/de/de2/neutral_gas_wats/wind2s_wats_cdaweb',
-             'remote_fname': '{year:4d}/' + fname,
-             'local_fname': fname}
+basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/neutral_gas_wats',
+                                    '/wind2s_wats_cdaweb/{year:4d}/')),
+             'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -85,7 +85,7 @@ tags = {'': '2 s cadence Wind and Temperature Spectrometer data'}
 inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
-fname = 'de2_wind2s_wats_{year:04d}{month:02d}{day:02d}_v01.cdf'
+fname = 'de2_wind2s_wats_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf'
 supported_tags = {'': {'': fname}}
 
 # use the CDAWeb methods list files routine

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -99,12 +99,12 @@ load = cdw.load
 basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/neutral_gas_wats',
                                     '/wind2s_wats_cdaweb/{year:4d}/')),
              'fname': fname}
-supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags)
+download_tags = {'': {'': basic_tag}}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 
 def init(self):

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -100,7 +100,7 @@ basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/neutral_gas_wats',
                                     '/wind2s_wats_cdaweb/{year:4d}/')),
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,

--- a/pysatNASA/instruments/formosat1_ivm.py
+++ b/pysatNASA/instruments/formosat1_ivm.py
@@ -51,11 +51,11 @@ load = cdw.load
 basic_tag = {'remote_dir': ''.join(('/pub/data/formosat-rocsat/formosat-1',
                                     '/ipei/{year:4d}/')),
              'fname': fname}
-supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags)
+download_tags = {'': {'': basic_tag}}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 
 def init(self):

--- a/pysatNASA/instruments/formosat1_ivm.py
+++ b/pysatNASA/instruments/formosat1_ivm.py
@@ -48,7 +48,8 @@ load = cdw.load
 
 # support download routine
 # use the default CDAWeb method
-basic_tag = {'remote_dir': '/pub/data/formosat-rocsat/formosat-1/ipei{year:4d}',
+basic_tag = {'remote_dir': ''.join(('/pub/data/formosat-rocsat/formosat-1',
+                                    '/ipei/{year:4d}/')),
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags=supported_tags)

--- a/pysatNASA/instruments/formosat1_ivm.py
+++ b/pysatNASA/instruments/formosat1_ivm.py
@@ -48,8 +48,7 @@ load = cdw.load
 
 # support download routine
 # use the default CDAWeb method
-basic_tag = {'remote_dir': '/pub/data/formosat-rocsat/formosat-1/ipei',
-             'remote_fname': '{year:4d}/' + fname,
+basic_tag = {'remote_dir': '/pub/data/formosat-rocsat/formosat-1/ipei{year:4d}',
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags=supported_tags)

--- a/pysatNASA/instruments/formosat1_ivm.py
+++ b/pysatNASA/instruments/formosat1_ivm.py
@@ -48,8 +48,8 @@ load = cdw.load
 
 # support download routine
 # use the default CDAWeb method
-basic_tag = {'remote_dir': ''.join(('/pub/data/formosat-rocsat/formosat-1',
-                                    '/ipei/{year:4d}/')),
+basic_tag = {'remote_dir': '/pub/data/formosat-rocsat/formosat-1/ipei',
+             'remote_fname': '{year:4d}/' + fname,
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags=supported_tags)
@@ -84,7 +84,7 @@ def init(self):
     return
 
 
-def clean(inst):
+def clean(self):
     """Routine to return FORMOSAT-1 IVM data cleaned to the specified level
 
     Parameters

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -69,7 +69,7 @@ list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # support download routine
-basic_tag = {'dir': '/pub/LEVEL.2/EUV',
+basic_tag = {'remote_dir': '/pub/LEVEL.2/EUV',
              'remote_fname': 'Data/' + fname}
 download_tags = {'': {'': basic_tag}}
 download = functools.partial(mm_icon.ssl_download, supported_tags=download_tags)

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -75,9 +75,9 @@ list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # support download routine
-basic_tag24 = {'dir': '/pub/LEVEL.2/FUV',
+basic_tag24 = {'remote_dir': '/pub/LEVEL.2/FUV',
                'remote_fname': fname24}
-basic_tag25 = {'dir': '/pub/LEVEL.2/FUV',
+basic_tag25 = {'remote_dir': '/pub/LEVEL.2/FUV',
                'remote_fname': fname25}
 
 download_tags = {'': {'day': basic_tag24,

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -77,9 +77,9 @@ list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # support download routine
-basic_tag_a = {'dir': '/pub/LEVEL.2/IVM-A',
+basic_tag_a = {'remote_dir': '/pub/LEVEL.2/IVM-A',
                'remote_fname': ''.join(('ZIP/', aname[:-2], 'ZIP'))}
-basic_tag_b = {'dir': '/pub/LEVEL.2/IVM-B',
+basic_tag_b = {'remote_dir': '/pub/LEVEL.2/IVM-B',
                'remote_fname': ''.join(('ZIP/', bname[:-2], 'ZIP'))}
 
 download_tags = {'a': {'': basic_tag_a},

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -118,7 +118,7 @@ for skey in supported_tags.keys():
     for tkey in supported_tags[skey].keys():
         fname = supported_tags[skey][tkey]
 
-        download_tags[skey][tkey] = {'dir': dirstr.format(id=ids[skey]),
+        download_tags[skey][tkey] = {'remote_dir': dirstr.format(id=ids[skey]),
                                      'remote_fname': ''.join((products[tkey],
                                                               fname))}
 

--- a/pysatNASA/instruments/iss_fpmu.py
+++ b/pysatNASA/instruments/iss_fpmu.py
@@ -54,7 +54,7 @@ basic_tag = {'remote_dir': ''.join(('/pub/data/international_space_station_iss',
                                     '/sp_fpmu/{year:4d}/')),
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,

--- a/pysatNASA/instruments/iss_fpmu.py
+++ b/pysatNASA/instruments/iss_fpmu.py
@@ -53,12 +53,12 @@ load = cdw.load
 basic_tag = {'remote_dir': ''.join(('/pub/data/international_space_station_iss',
                                     '/sp_fpmu/{year:4d}/')),
              'fname': fname}
-supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags)
+download_tags = {'': {'': basic_tag}}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 
 def init(self):

--- a/pysatNASA/instruments/iss_fpmu.py
+++ b/pysatNASA/instruments/iss_fpmu.py
@@ -50,9 +50,9 @@ load = cdw.load
 
 # support download routine
 # use the default CDAWeb method
-basic_tag = {'dir': '/pub/data/international_space_station_iss/sp_fpmu',
-             'remote_fname': '{year:4d}/' + fname,
-             'local_fname': fname}
+basic_tag = {'remote_dir': ''.join(('/pub/data/international_space_station_iss',
+                                    '/sp_fpmu/{year:4d}/')),
+             'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 

--- a/pysatNASA/instruments/iss_fpmu.py
+++ b/pysatNASA/instruments/iss_fpmu.py
@@ -40,7 +40,7 @@ _test_dates = {'': {'': dt.datetime(2017, 10, 1)}}
 
 # support list files routine
 # use the default CDAWeb method
-fname = 'iss_sp_fpmu_{year:04d}{month:02d}{day:02d}_v01.cdf'
+fname = 'iss_sp_fpmu_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf'
 supported_tags = {'': {'': fname}}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -96,11 +96,10 @@ def load(fnames, tag=None, inst_id=None,
                 return cdf.to_pysat(flatten_twod=flatten_twod)
 
 
-def download(supported_tags, date_array, tag, inst_id,
+def download(date_array, tag, inst_id, supported_tags=None,
              remote_url='https://cdaweb.gsfc.nasa.gov',
              data_path=None, user=None, password=None,
-             fake_daily_files_from_monthly=False,
-             multi_file_day=False):
+             fake_daily_files_from_monthly=False):
     """Routine to download NASA CDAWeb CDF data.
 
     This routine is intended to be used by pysat instrument modules supporting
@@ -108,16 +107,17 @@ def download(supported_tags, date_array, tag, inst_id,
 
     Parameters
     -----------
-    supported_tags : dict
-        dict of dicts. Keys are supported tag names for download. Value is
-        a dict with 'remote_dir', fname'. Inteded to be pre-set with
-        functools.partial then assigned to new instrument code.
     date_array : array_like
         Array of datetimes to download data for. Provided by pysat.
     tag : str or NoneType
         tag or None (default=None)
     inst_id : (str or NoneType)
         satellite id or None (default=None)
+    supported_tags : dict
+        dict of dicts. Keys are supported tag names for download. Value is
+        a dict with 'remote_dir', fname'. Inteded to be pre-set with
+        functools.partial then assigned to new instrument code.
+        (default=None)
     remote_url : string or NoneType
         Remote site to download data from
         (default='https://cdaweb.gsfc.nasa.gov')
@@ -226,6 +226,7 @@ def list_remote_files(tag, inst_id,
         dict of dicts. Keys are supported tag names for download. Value is
         a dict with 'remote_dir', 'remote_loc', 'fname'. Inteded to be
         pre-set with functools.partial then assigned to new instrument code.
+        (default=None)
     user : string or NoneType
         Username to be passed along to resource with relevant data.
         (default=None)

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -97,7 +97,7 @@ def load(fnames, tag=None, inst_id=None,
 
 
 def download(supported_tags, date_array, tag, inst_id,
-             remote_site='https://cdaweb.gsfc.nasa.gov',
+             remote_url='https://cdaweb.gsfc.nasa.gov',
              data_path=None, user=None, password=None,
              fake_daily_files_from_monthly=False,
              multi_file_day=False):
@@ -118,7 +118,7 @@ def download(supported_tags, date_array, tag, inst_id,
         tag or None (default=None)
     inst_id : (str or NoneType)
         satellite id or None (default=None)
-    remote_site : string or NoneType
+    remote_url : string or NoneType
         Remote site to download data from
         (default='https://cdaweb.gsfc.nasa.gov')
     data_path : string or NoneType
@@ -158,15 +158,12 @@ def download(supported_tags, date_array, tag, inst_id,
     except KeyError:
         raise ValueError('inst_id / tag combo unknown.')
 
-    # path to relevant file on CDAWeb
-    remote_url = remote_site
-
     # naming scheme for files on the CDAWeb server
     remote_dir = inst_dict['remote_dir']
 
     # Get list of files from server
     remote_files = list_remote_files(tag=tag, inst_id=inst_id,
-                                     remote_site=remote_site,
+                                     remote_url=remote_url,
                                      supported_tags=supported_tags,
                                      start=date_array[0],
                                      stop=date_array[-1])
@@ -205,7 +202,7 @@ def download(supported_tags, date_array, tag, inst_id,
 
 
 def list_remote_files(tag, inst_id,
-                      remote_site='https://cdaweb.gsfc.nasa.gov',
+                      remote_url='https://cdaweb.gsfc.nasa.gov',
                       supported_tags=None,
                       user=None, password=None,
                       fake_daily_files_from_monthly=False,
@@ -224,7 +221,7 @@ def list_remote_files(tag, inst_id,
     inst_id : string or NoneType
         Specifies the satellite ID for a constellation.
         (default=None)
-    remote_site : string or NoneType
+    remote_url : string or NoneType
         Remote site to download data from
         (default='https://cdaweb.gsfc.nasa.gov')
     supported_tags : dict
@@ -292,7 +289,7 @@ def list_remote_files(tag, inst_id,
         raise ValueError('inst_id / tag combo unknown.')
 
     # path to relevant file on CDAWeb
-    remote_url = remote_site
+    remote_url = remote_url
 
     # naming scheme for files on the CDAWeb server
     format_str = '/'.join((inst_dict['remote_dir'].strip('/'),

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -110,8 +110,8 @@ def download(supported_tags, date_array, tag, inst_id,
     -----------
     supported_tags : dict
         dict of dicts. Keys are supported tag names for download. Value is
-        a dict with 'remote_dir', 'remote_loc', 'fname'. Inteded to be
-        pre-set with functools.partial then assigned to new instrument code.
+        a dict with 'remote_dir', fname'. Inteded to be pre-set with
+        functools.partial then assigned to new instrument code.
     date_array : array_like
         Array of datetimes to download data for. Provided by pysat.
     tag : str or NoneType
@@ -140,12 +140,10 @@ def download(supported_tags, date_array, tag, inst_id,
     ::
 
         # download support added to cnofs_vefi.py using code below
-        rn = '{year:4d}/cnofs_vefi_bfield_1sec_{year:4d}{month:02d}{day:02d}'+
-            '_v05.cdf'
-        ln = 'cnofs_vefi_bfield_1sec_{year:4d}{month:02d}{day:02d}_v05.cdf'
-        dc_b_tag = {'remote_dir':'/pub/data/cnofs/vefi/bfield_1sec',
-                    'remote_loc': rn,
-                    'fname': ln}
+        fn = 'cnofs_vefi_bfield_1sec_{year:4d}{month:02d}{day:02d}_v05.cdf'
+        dc_b_tag = {'remote_dir': ''.join(('/pub/data/cnofs/vefi/bfield_1sec',
+                                            '/{year:4d}/')),
+                    'fname': fn}
         supported_tags = {'dc_b': dc_b_tag}
 
         download = functools.partial(nasa_cdaweb.download,

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -165,11 +165,8 @@ def download(date_array, tag=None, inst_id=None, supported_tags=None,
                                      supported_tags=supported_tags,
                                      start=date_array[0],
                                      stop=date_array[-1])
-    # Find only requested files that exist remotely
-    date_array = pds.DatetimeIndex(list(set(remote_files.index)
-                                        & set(date_array))).sort_values()
-
-    for date, fname in remote_files[date_array].iteritems():
+    # Download only requested files that exist remotely
+    for date, fname in remote_files.iteritems():
         # format files for specific dates and download location
         formatted_remote_dir = remote_dir.format(year=date.year,
                                                  month=date.month,
@@ -372,7 +369,9 @@ def list_remote_files(tag=None, inst_id=None,
     if start is not None:
         mask = (stored_list.index >= start)
         if stop is not None:
-            mask = mask & (stored_list.index <= stop + pds.DateOffset(days=1))
+            stop_point = (stop + pds.DateOffset(days=1)
+                          - pds.DateOffset(microseconds=1))
+            mask = mask & (stored_list.index <= stop_point)
         stored_list = stored_list[mask]
 
     return stored_list

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -221,7 +221,7 @@ def list_remote_files(tag=None, inst_id=None,
         (default='https://cdaweb.gsfc.nasa.gov')
     supported_tags : dict
         dict of dicts. Keys are supported tag names for download. Value is
-        a dict with 'remote_dir', 'remote_loc', 'fname'. Inteded to be
+        a dict with 'remote_dir', fname'. Inteded to be
         pre-set with functools.partial then assigned to new instrument code.
         (default=None)
     user : string or NoneType

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -110,7 +110,7 @@ def download(supported_tags, date_array, tag, inst_id,
     -----------
     supported_tags : dict
         dict of dicts. Keys are supported tag names for download. Value is
-        a dict with 'dir', 'remote_fname', 'local_fname'. Inteded to be
+        a dict with 'remote_dir', 'remote_loc', 'fname'. Inteded to be
         pre-set with functools.partial then assigned to new instrument code.
     date_array : array_like
         Array of datetimes to download data for. Provided by pysat.
@@ -143,9 +143,9 @@ def download(supported_tags, date_array, tag, inst_id,
         rn = '{year:4d}/cnofs_vefi_bfield_1sec_{year:4d}{month:02d}{day:02d}'+
             '_v05.cdf'
         ln = 'cnofs_vefi_bfield_1sec_{year:4d}{month:02d}{day:02d}_v05.cdf'
-        dc_b_tag = {'dir':'/pub/data/cnofs/vefi/bfield_1sec',
-                    'remote_fname': rn,
-                    'local_fname': ln}
+        dc_b_tag = {'remote_dir':'/pub/data/cnofs/vefi/bfield_1sec',
+                    'remote_loc': rn,
+                    'fname': ln}
         supported_tags = {'dc_b': dc_b_tag}
 
         download = functools.partial(nasa_cdaweb.download,
@@ -159,94 +159,49 @@ def download(supported_tags, date_array, tag, inst_id,
         raise ValueError('inst_id / tag combo unknown.')
 
     # path to relevant file on CDAWeb
-    remote_url = remote_site + inst_dict['dir']
+    remote_url = remote_site
 
     # naming scheme for files on the CDAWeb server
-    remote_fname = inst_dict['remote_fname']
+    remote_dir = inst_dict['remote_dir']
 
-    # naming scheme for local files, should be closely related
-    # to CDAWeb scheme, though directory structures may be reduced
-    # if desired
-    local_fname = inst_dict['local_fname']
+    # Get list of files from server
+    remote_files = list_remote_files(tag=tag, inst_id=inst_id,
+                                     remote_site=remote_site,
+                                     supported_tags=supported_tags,
+                                     start=date_array[0],
+                                     stop=date_array[-1])
+    # Find only requested files that exist remotely
+    date_array = pds.DatetimeIndex(list(set(remote_files.index)
+                                        & set(date_array))).sort_values()
 
-    if not multi_file_day:
-        # Get list of files from server
-        remote_files = list_remote_files(tag=tag, inst_id=inst_id,
-                                         remote_site=remote_site,
-                                         supported_tags=supported_tags,
-                                         start=date_array[0],
-                                         stop=date_array[-1])
-        # Find only requested files that exist remotely
-        date_array = pds.DatetimeIndex(list(set(remote_files.index)
-                                            & set(date_array))).sort_values()
-
-    for date in date_array:
+    for date, fname in remote_files[date_array].iteritems():
         # format files for specific dates and download location
-        formatted_remote_fname = remote_fname.format(year=date.year,
-                                                     month=date.month,
-                                                     day=date.day,
-                                                     hour=date.hour,
-                                                     min=date.minute,
-                                                     sec=date.second)
-        formatted_local_fname = local_fname.format(year=date.year,
-                                                   month=date.month,
-                                                   day=date.day,
-                                                   hour=date.hour,
-                                                   min=date.minute,
-                                                   sec=date.second)
-        saved_local_fname = os.path.join(data_path, formatted_local_fname)
+        formatted_remote_dir = remote_dir.format(year=date.year,
+                                                 month=date.month,
+                                                 day=date.day,
+                                                 hour=date.hour,
+                                                 min=date.minute,
+                                                 sec=date.second)
+        saved_local_fname = os.path.join(data_path, fname)
 
         # perform download
-        if not multi_file_day:
-            # standard download
-            try:
-                logger.info(' '.join(('Attempting to download file for',
+        try:
+            logger.info(' '.join(('Attempting to download file for',
+                                  date.strftime('%d %B %Y'))))
+            sys.stdout.flush()
+            remote_path = '/'.join((remote_url.strip('/'),
+                                    formatted_remote_dir.strip('/'),
+                                    fname))
+            req = requests.get(remote_path)
+            if req.status_code != 404:
+                open(saved_local_fname, 'wb').write(req.content)
+                logger.info('Finished.')
+            else:
+                logger.info(' '.join(('File not available for',
                                       date.strftime('%d %B %Y'))))
-                sys.stdout.flush()
-                remote_path = '/'.join((remote_url.strip('/'),
-                                        formatted_remote_fname))
-                req = requests.get(remote_path)
-                if req.status_code != 404:
-                    open(saved_local_fname, 'wb').write(req.content)
-                    logger.info('Finished.')
-                else:
-                    logger.info(' '.join(('File not available for',
-                                          date.strftime('%d %B %Y'))))
-            except requests.exceptions.RequestException as exception:
-                logger.info(' '.join((exception, '- File not available for',
-                                      date.strftime('%d %B %Y'))))
-
-        else:
-            try:
-                logger.info(' '.join(('Attempting to download files for',
-                                      date.strftime('%d %B %Y'))))
-                sys.stdout.flush()
-                remote_files = list_remote_files(tag=tag, inst_id=inst_id,
-                                                 remote_site=remote_site,
-                                                 supported_tags=supported_tags,
-                                                 start=date,
-                                                 stop=date)
-
-                # Get the files
-                i = 0
-                n = len(remote_files.values)
-                for remote_file in remote_files.values:
-                    remote_dir = os.path.split(formatted_remote_fname)[0]
-                    remote_file_path = '/'.join((remote_url.strip('/'),
-                                                 remote_dir.strip('/'),
-                                                 remote_file))
-                    saved_local_fname = os.path.join(data_path, remote_file)
-                    req = requests.get(remote_file_path)
-                    if req.status_code != 404:
-                        open(saved_local_fname, 'wb').write(req.content)
-                        i += 1
-                    else:
-                        logger.info(' '.join(('File not available for',
-                                              date.strftime('%d %B %Y'))))
-                logger.info('Downloaded {i:} of {n:} files.'.format(i=i, n=n))
-            except requests.exceptions.RequestException as exception:
-                logger.info(' '.join((exception, '- Files not available for',
-                                      date.strftime('%d %B %Y'))))
+        except requests.exceptions.RequestException as exception:
+            logger.info(' '.join((exception, '- File not available for',
+                                  date.strftime('%d %B %Y'))))
 
 
 def list_remote_files(tag, inst_id,
@@ -274,7 +229,7 @@ def list_remote_files(tag, inst_id,
         (default='https://cdaweb.gsfc.nasa.gov')
     supported_tags : dict
         dict of dicts. Keys are supported tag names for download. Value is
-        a dict with 'dir', 'remote_fname', 'local_fname'. Inteded to be
+        a dict with 'remote_dir', 'remote_loc', 'fname'. Inteded to be
         pre-set with functools.partial then assigned to new instrument code.
     user : string or NoneType
         Username to be passed along to resource with relevant data.
@@ -337,10 +292,11 @@ def list_remote_files(tag, inst_id,
         raise ValueError('inst_id / tag combo unknown.')
 
     # path to relevant file on CDAWeb
-    remote_url = remote_site + inst_dict['dir']
+    remote_url = remote_site
 
     # naming scheme for files on the CDAWeb server
-    format_str = inst_dict['remote_fname']
+    format_str = '/'.join((inst_dict['remote_dir'].strip('/'),
+                           inst_dict['fname']))
 
     # Break string format into path and filename
     dir_split = os.path.split(format_str)

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -372,7 +372,7 @@ def list_remote_files(tag=None, inst_id=None,
     if start is not None:
         mask = (stored_list.index >= start)
         if stop is not None:
-            mask = mask & (stored_list.index <= stop)
+            mask = mask & (stored_list.index <= stop + pds.DateOffset(days=1))
         stored_list = stored_list[mask]
 
     return stored_list

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -96,7 +96,7 @@ def load(fnames, tag=None, inst_id=None,
                 return cdf.to_pysat(flatten_twod=flatten_twod)
 
 
-def download(date_array, tag, inst_id, supported_tags=None,
+def download(date_array, tag=None, inst_id=None, supported_tags=None,
              remote_url='https://cdaweb.gsfc.nasa.gov',
              data_path=None, user=None, password=None,
              fake_daily_files_from_monthly=False):
@@ -199,7 +199,7 @@ def download(date_array, tag, inst_id, supported_tags=None,
                                   date.strftime('%d %B %Y'))))
 
 
-def list_remote_files(tag, inst_id,
+def list_remote_files(tag=None, inst_id=None,
                       remote_url='https://cdaweb.gsfc.nasa.gov',
                       supported_tags=None,
                       user=None, password=None,

--- a/pysatNASA/instruments/methods/icon.py
+++ b/pysatNASA/instruments/methods/icon.py
@@ -178,7 +178,7 @@ def list_remote_files(tag, inst_id, user=None, password=None,
     # path to highest directory, below which is custom structure
     # and files
     # change directory
-    ftp.cwd(ftp_dict['dir'])
+    ftp.cwd(ftp_dict['remote_dir'])
     # get directory contents
     ftp.dir(temp_dirs.append)
     # need to parse output to obtain list of paths to years
@@ -186,7 +186,7 @@ def list_remote_files(tag, inst_id, user=None, password=None,
         # parse raw string
         parsed = item.split(' ')
         # print(parsed[-1])
-        remote_years.append(ftp_dict['dir'] + '/' + parsed[-1])
+        remote_years.append(ftp_dict['remote_dir'] + '/' + parsed[-1])
         years.append(parsed[-1])
 
     # get files under each year, first identify day directories

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -70,8 +70,8 @@ _test_dates = {'': {'1min': dt.datetime(2009, 1, 1),
 
 # support list files routine
 # use the default CDAWeb method
-fname1 = 'omni_hro_1min_{year:4d}{month:02d}{day:02d}_v01.cdf'
-fname5 = 'omni_hro_5min_{year:4d}{month:02d}{day:02d}_v01.cdf'
+fname1 = 'omni_hro_1min_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf'
+fname5 = 'omni_hro_5min_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf'
 supported_tags = {'': {'1min': fname1,
                        '5min': fname5}}
 list_files = functools.partial(mm_gen.list_files,

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -88,14 +88,14 @@ basic_tag1 = {'remote_dir': '/pub/data/omni/omni_cdaweb/hro_1min/{year:4d}/',
               'fname': fname1}
 basic_tag5 = {'remote_dir': '/pub/data/omni/omni_cdaweb/hro_5min/{year:4d}/',
               'fname': fname5}
-supported_tags = {'': {'1min': basic_tag1,
-                       '5min': basic_tag5}}
+download_tags = {'': {'1min': basic_tag1,
+                      '5min': basic_tag5}}
 download = functools.partial(cdw.download,
-                             supported_tags=supported_tags,
+                             supported_tags=download_tags,
                              fake_daily_files_from_monthly=True)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 
 def init(self):

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -84,12 +84,10 @@ load = functools.partial(cdw.load, fake_daily_files_from_monthly=True)
 
 # support download routine
 # use the default CDAWeb method
-basic_tag1 = {'dir': '/pub/data/omni/omni_cdaweb/hro_1min',
-              'remote_fname': '{year:4d}/' + fname1,
-              'local_fname': fname1}
-basic_tag5 = {'dir': '/pub/data/omni/omni_cdaweb/hro_5min',
-              'remote_fname': '{year:4d}/' + fname5,
-              'local_fname': fname5}
+basic_tag1 = {'remote_dir': '/pub/data/omni/omni_cdaweb/hro_1min/{year:4d}/',
+              'fname': fname1}
+basic_tag5 = {'remote_dir': '/pub/data/omni/omni_cdaweb/hro_5min/{year:4d}/',
+              'fname': fname5}
 supported_tags = {'': {'1min': basic_tag1,
                        '5min': basic_tag5}}
 download = functools.partial(cdw.download,

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -91,7 +91,7 @@ basic_tag5 = {'remote_dir': '/pub/data/omni/omni_cdaweb/hro_5min/{year:4d}/',
 supported_tags = {'': {'1min': basic_tag1,
                        '5min': basic_tag5}}
 download = functools.partial(cdw.download,
-                             supported_tags,
+                             supported_tags=supported_tags,
                              fake_daily_files_from_monthly=True)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,

--- a/pysatNASA/instruments/rocsat1_ivm.py
+++ b/pysatNASA/instruments/rocsat1_ivm.py
@@ -52,7 +52,7 @@ basic_tag = {'remote_dir': ''.join(('/pub/data/formosat-rocsat/formosat-1',
                                     '/ipei/{year:4d}/')),
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=supported_tags)

--- a/pysatNASA/instruments/rocsat1_ivm.py
+++ b/pysatNASA/instruments/rocsat1_ivm.py
@@ -48,9 +48,9 @@ load = cdw.load
 
 # support download routine
 # use the default CDAWeb method
-basic_tag = {'dir': '/pub/data/formosat-rocsat/formosat-1/ipei',
-             'remote_fname': '{year:4d}/' + fname,
-             'local_fname': fname}
+basic_tag = {'remote_dir': ''.join(('/pub/data/formosat-rocsat/formosat-1',
+                                    '/ipei/{year:4d}/')),
+             'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 # support listing files currently on CDAWeb

--- a/pysatNASA/instruments/rocsat1_ivm.py
+++ b/pysatNASA/instruments/rocsat1_ivm.py
@@ -38,7 +38,7 @@ _test_dates = {'': {'': dt.datetime(2002, 1, 1)}}
 
 # support list files routine
 # use the default CDAWeb method
-fname = 'rs_k0_ipei_{year:04d}{month:02d}{day:02d}_v01.cdf'
+fname = 'rs_k0_ipei_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf'
 supported_tags = {'': {'': fname}}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)

--- a/pysatNASA/instruments/sport_ivm.py
+++ b/pysatNASA/instruments/sport_ivm.py
@@ -134,14 +134,8 @@ def download(date_array, tag, inst_id, data_path=None, user=None,
     pass
 
 
-def clean(inst):
+def clean(self):
     """Routine to return SPORT IVM data cleaned to the specified level
-
-    Parameters
-    -----------
-    inst : pysat.Instrument
-        Instrument class object, whose attribute clean_level is used to return
-        the desired level of data selectivity.
 
     Note
     ----
@@ -151,4 +145,4 @@ def clean(inst):
 
     warnings.warn("No cleaning currently available for SPORT")
 
-    return None
+    return

--- a/pysatNASA/instruments/sport_ivm.py
+++ b/pysatNASA/instruments/sport_ivm.py
@@ -132,3 +132,23 @@ def download(date_array, tag, inst_id, data_path=None, user=None,
     warnings.warn('Downloads are not currently supported - not launched yet!')
 
     pass
+
+
+def clean(inst):
+    """Routine to return SPORT IVM data cleaned to the specified level
+
+    Parameters
+    -----------
+    inst : pysat.Instrument
+        Instrument class object, whose attribute clean_level is used to return
+        the desired level of data selectivity.
+
+    Note
+    ----
+    No cleaning currently available for SPORT IVM.
+
+    """
+
+    warnings.warn("No cleaning currently available for SPORT")
+
+    return None

--- a/pysatNASA/instruments/templates/template_cdaweb_instrument.py
+++ b/pysatNASA/instruments/templates/template_cdaweb_instrument.py
@@ -123,7 +123,7 @@ basic_tag = {'remote_dir': '/pub/data/cnofs/vefi/bfield_1sec',
              'remote_fname': '{year:4d}/' + fname,
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,

--- a/pysatNASA/instruments/templates/template_cdaweb_instrument.py
+++ b/pysatNASA/instruments/templates/template_cdaweb_instrument.py
@@ -119,9 +119,9 @@ load = cdw.load
 # a dictionary needs to be created for each inst_id and tag
 # combination along with the file format template
 # outer dict keyed by inst_id, inner dict keyed by tag
-basic_tag = {'dir': '/pub/data/cnofs/vefi/bfield_1sec',
+basic_tag = {'remote_dir': '/pub/data/cnofs/vefi/bfield_1sec',
              'remote_fname': '{year:4d}/' + fname,
-             'local_fname': fname}
+             'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -63,7 +63,7 @@ inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
 
 fname = ''.join(('timed_l2av207_saber_{year:04d}{month:02d}{day:02d}',
-                 '????_v{version:02d}.cdf'))
+                 '{hour:02d}{minute:02d}_v{version:02d}.cdf'))
 supported_tags = {'': {'': fname}}
 # use the CDAWeb methods list files routine
 list_files = functools.partial(mm_gen.list_files,

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -63,7 +63,7 @@ inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
 
 fname = ''.join(('timed_l2av207_saber_{year:04d}{month:02d}{day:02d}',
-                 '????_v01.cdf'))
+                 '????_v{version:02d}.cdf'))
 supported_tags = {'': {'': fname}}
 # use the CDAWeb methods list files routine
 list_files = functools.partial(mm_gen.list_files,

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -83,12 +83,12 @@ load = cdw.load
 basic_tag = {'remote_dir': ''.join(('/pub/data/timed/saber/level2a_v2_07_cdf',
                                     '/{year:4d}/{month:02d}/')),
              'fname': fname}
-supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags)
+download_tags = {'': {'': basic_tag}}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 
 def init(self):

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -80,9 +80,9 @@ pandas_format = True
 load = cdw.load
 
 # use the default CDAWeb method
-basic_tag = {'dir': '/pub/data/timed/saber/level2a_v2_07_cdf',
-             'remote_fname': '{year:4d}/{month:02d}/' + fname,
-             'local_fname': fname}
+basic_tag = {'remote_dir': ''.join(('/pub/data/timed/saber/level2a_v2_07_cdf',
+                                    '/{year:4d}/{month:02d}/')),
+             'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags, multi_file_day=True)
 

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -84,7 +84,7 @@ basic_tag = {'remote_dir': ''.join(('/pub/data/timed/saber/level2a_v2_07_cdf',
                                     '/{year:4d}/{month:02d}/')),
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags, multi_file_day=True)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -68,7 +68,7 @@ basic_tag = {'remote_dir': ''.join(('/pub/data/timed/see/data/level3a_cdf',
                                     '/{year:4d}/{month:02d}/')),
              'fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
+download = functools.partial(cdw.download, supported_tags=supported_tags)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=supported_tags)

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -56,7 +56,7 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 # support list files routine
 # use the default CDAWeb method
-fname = 'timed_l3a_see_{year:04d}{month:02d}{day:02d}_v01.cdf'
+fname = 'timed_l3a_see_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf'
 supported_tags = {'': {'': fname}}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags,

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -64,9 +64,9 @@ list_files = functools.partial(mm_gen.list_files,
 
 # support download routine
 # use the default CDAWeb method
-basic_tag = {'dir': '/pub/data/timed/see/data/level3a_cdf',
-             'remote_fname': '{year:4d}/{month:02d}/' + fname,
-             'local_fname': fname}
+basic_tag = {'remote_dir': ''.join(('/pub/data/timed/see/data/level3a_cdf',
+                                    '/{year:4d}/{month:02d}/')),
+             'fname': fname}
 supported_tags = {'': {'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 # support listing files currently on CDAWeb

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -67,11 +67,11 @@ list_files = functools.partial(mm_gen.list_files,
 basic_tag = {'remote_dir': ''.join(('/pub/data/timed/see/data/level3a_cdf',
                                     '/{year:4d}/{month:02d}/')),
              'fname': fname}
-supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags)
+download_tags = {'': {'': basic_tag}}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
-                                      supported_tags=supported_tags)
+                                      supported_tags=download_tags)
 
 # support load routine
 # use the default CDAWeb method

--- a/pysatNASA/tests/test_methods_cdaweb.py
+++ b/pysatNASA/tests/test_methods_cdaweb.py
@@ -11,19 +11,19 @@ class TestCDAWeb():
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""
-        self.supported_tags = pysatNASA.instruments.cnofs_plp.supported_tags
+        self.download_tags = pysatNASA.instruments.cnofs_plp.download_tags
         self.kwargs = {'tag': None, 'inst_id': None}
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.supported_tags, self.kwargs
+        del self.download_tags, self.kwargs
 
     def test_remote_file_list_connection_error_append(self):
         """pysat should append suggested help to ConnectionError"""
         with pytest.raises(Exception) as excinfo:
             # Giving a bad remote_site address yields similar ConnectionError
             cdw.list_remote_files(tag='', inst_id='',
-                                  supported_tags=self.supported_tags,
+                                  supported_tags=self.download_tags,
                                   remote_url='https://bad/path')
 
         assert excinfo.type is requests.exceptions.ConnectionError
@@ -44,7 +44,7 @@ class TestCDAWeb():
         date_array = [dt.datetime(2019, 1, 1)]
         self.kwargs[bad_key] = bad_val
         with pytest.raises(ValueError) as excinfo:
-            cdw.download(supported_tags=self.supported_tags,
+            cdw.download(supported_tags=self.download_tags,
                          date_array=date_array,
                          tag=self.kwargs['tag'],
                          inst_id=self.kwargs['inst_id'])
@@ -57,7 +57,7 @@ class TestCDAWeb():
     def test_bad_kwarg_list_remote_files(self, bad_key, bad_val, err_msg):
         self.kwargs[bad_key] = bad_val
         with pytest.raises(ValueError) as excinfo:
-            cdw.list_remote_files(supported_tags=self.supported_tags,
+            cdw.list_remote_files(supported_tags=self.download_tags,
                                   tag=self.kwargs['tag'],
                                   inst_id=self.kwargs['inst_id'])
         assert str(excinfo.value).find(err_msg) >= 0

--- a/pysatNASA/tests/test_methods_cdaweb.py
+++ b/pysatNASA/tests/test_methods_cdaweb.py
@@ -24,7 +24,7 @@ class TestCDAWeb():
             # Giving a bad remote_site address yields similar ConnectionError
             cdw.list_remote_files(tag='', inst_id='',
                                   supported_tags=self.supported_tags,
-                                  remote_url='http:/')
+                                  remote_url='https://bad/path')
 
         assert excinfo.type is requests.exceptions.ConnectionError
         # Check that pysat appends the message

--- a/pysatNASA/tests/test_methods_cdaweb.py
+++ b/pysatNASA/tests/test_methods_cdaweb.py
@@ -24,7 +24,7 @@ class TestCDAWeb():
             # Giving a bad remote_site address yields similar ConnectionError
             cdw.list_remote_files(tag='', inst_id='',
                                   supported_tags=self.supported_tags,
-                                  remote_site='http:/')
+                                  remote_url='http:/')
 
         assert excinfo.type is requests.exceptions.ConnectionError
         # Check that pysat appends the message


### PR DESCRIPTION
This pull streamlines the cdaweb download routine.
- Removes separate routines for the multi_file_day instruments
- Reduce custom instrument name and directory strings to two

Old code 
- Workflow
  - Ask the server what files are available
  - Decide how many loops to iterate based on `multi_file_day`
  - Iterate over years, months, etc to individually construct filenames using `.format`
- Uses 'dir', 'remote_fname', 'local_fname' as part of `supported_tags`
- Has the capability of renaming files locally, but politely asks users to keep the same file names
- Included both `remote_site` and `remote_url` variables
- `supported_tags` an arg in `download`, kwarg in `list_remote_files`

New code
- Workflow
  - Ask the server what files are available
  - Iterate over that list to download files, using known file names
- Uses 'remote_dir', 'fname' as part of `supported_tags`
- Maintains file names locally
- Uses only `remote_url` consistently
- Incorporates version numbers in file names
- `supported_tags` treated as a kwarg in all routines

This will also help prepare the code for the implementation of version / revision / cycle required by #7.

Note this does not affect ICON instruments, though some renaming of the ftp dicts have been done for consistency.