### PR TITLE
DOC: use travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pysatNASA: pysat support for NASA instruments
-[![Build Status](https://travis-ci.org/pysat/pysatNASA.svg?branch=main)](https://travis-ci.org/pysat/pysatNASA)
+[![Build Status](https://travis-ci.com/pysat/pysatNASA.svg?branch=main)](https://travis-ci.com/pysat/pysatNASA)
 [![Coverage Status](https://coveralls.io/repos/github/pysat/pysatNASA/badge.svg?branch=main)](https://coveralls.io/github/pysat/pysatNASA?branch=main)
 [![DOI](https://zenodo.org/badge/287387638.svg)](https://zenodo.org/badge/latestdoi/287387638)
 


### PR DESCRIPTION
Updates the front page to point to the travis-ci.com badges.  Travis plans to finish migrating to the new site by Dec 31, 2020.