### PR TITLE
BUG: update GOLD NMAX tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ install:
   - pip install coveralls
   - pip install pytest-flake8
   - pip install portalocker
+  # Dependencies not available through conda, install through pip
+  - pip install pysatCDF >/dev/null
   # Custom pysat install
   - cd ..
   - git clone https://github.com/pysat/pysat.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ install:
   # Get latest coveralls from pip, not conda
   - pip install coveralls
   - pip install pytest-flake8
-  # Dependencies not available through conda, install through pip
-  - pip install pysatCDF >/dev/null
+  - pip install portalocker
   # Custom pysat install
   - cd ..
   - git clone https://github.com/pysat/pysat.git

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -114,16 +114,20 @@ def clean(self):
 # Use the pysat and CDAWeb methods
 
 # Set the list_files routine
-fname = ''.join(('gold_l2_nmax_{year:04d}_{day:03d}_v{version:02d}',
-                 '_r{revision:02d}_c{cycle:02d}.nc'))
-supported_tags = {'': {'nmax': fname}}
+fname = ''.join(('gold_l2_{tag:s}_{{year:04d}}_{{day:03d}}_v{{version:02d}}',
+                 '_r{{revision:02d}}_c{{cycle:02d}}.nc'))
+supported_tags = {'': {}}
+for tag in inst_ids['']:
+    supported_tags[''][tag] = fname.format(tag=tag)
 list_files = functools.partial(ps_gen.list_files,
                                supported_tags=supported_tags)
 
 # Set the download routine
-basic_tag = {'remote_dir': '/pub/data/gold/level2/nmax/{year:4d}/',
-             'fname': fname}
-download_tags = {'': {'nmax': basic_tag}}
+download_tags = {'': {}}
+for tag in inst_ids['']:
+    download_tags[''][tag] = {'remote_dir': ''.join(('/pub/data/gold/level2/',
+                                                     tag, '/{year:4d}/')),
+                              'fname': fname.format(tag=tag)}
 download = functools.partial(cdw.download, supported_tags=download_tags)
 
 # Set the list_remote_files routine

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -180,15 +180,16 @@ def load(fnames, tag=None, inst_id=None):
     """
 
     data, mdata = load_netcdf4(fnames, pandas_format=pandas_format)
-    # Add time coordinate from scan_start_time
-    data['time'] = ('nscans',
-                    [dt.datetime.strptime(str(val), "b'%Y-%m-%dT%H:%M:%SZ'")
-                     for val in data['scan_start_time'].values])
-    data = data.swap_dims({'nscans': 'time'})
-    data = data.assign_coords({'nlats': data['nlats'],
-                               'nlons': data['nlons'],
-                               'nmask': data['nmask'],
-                               'channel': data['channel'],
-                               'hemisphere': data['hemisphere']})
+    if tag == 'nmax':
+        # Add time coordinate from scan_start_time
+        data['time'] = ('nscans',
+                        [dt.datetime.strptime(str(val), "b'%Y-%m-%dT%H:%M:%SZ'")
+                         for val in data['scan_start_time'].values])
+        data = data.swap_dims({'nscans': 'time'})
+        data = data.assign_coords({'nlats': data['nlats'],
+                                   'nlons': data['nlons'],
+                                   'nmask': data['nmask'],
+                                   'channel': data['channel'],
+                                   'hemisphere': data['hemisphere']})
 
     return data, mdata

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -116,14 +116,14 @@ def clean(self):
 # Set the list_files routine
 fname = ''.join(('gold_l2_nmax_{year:04d}_{day:03d}_v{version:02d}',
                  '_r{revision:02d}_c{cycle:02d}.nc'))
-supported_tags = {'': {'': fname}}
+supported_tags = {'': {'nmax': fname}}
 list_files = functools.partial(ps_gen.list_files,
                                supported_tags=supported_tags)
 
 # Set the download routine
 basic_tag = {'remote_dir': '/pub/data/gold/level2/nmax/{year:4d}/',
              'fname': fname}
-download_tags = {'': {'': basic_tag}}
+download_tags = {'': {'nmax': basic_tag}}
 download = functools.partial(cdw.download, supported_tags=download_tags)
 
 # Set the list_remote_files routine


### PR DESCRIPTION
Fixing the tags for ses14_gold.  Trying to load the gold instrument manually into pysat produced an error:
```
In [11]: nmax = pysat.Instrument(inst_module=pysatNASA.instruments.ses14_gold, tag='nmax', strict_time_flag=False)
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/code/core/pysat/pysat/instruments/methods/general.py in list_files(tag, inst_id, data_path, format_str, supported_tags, fake_daily_files_from_monthly, two_digit_year_break, delimiter)
     82         try:
---> 83             format_str = supported_tags[inst_id][tag]
     84         except KeyError as kerr:

KeyError: 'nmax'

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
<ipython-input-11-739a97ac3a2f> in <module>
----> 1 nmax = pysat.Instrument(inst_module=pysatNASA.instruments.ses14_gold, tag='nmax', strict_time_flag=False)

~/code/core/pysat/pysat/_instrument.py in __init__(self, platform, name, tag, inst_id, clean_level, update_files, pad, orbit_info, inst_module, multi_file_day, manual_org, directory_format, file_format, temporary_file_list, strict_time_flag, ignore_empty_files, units_label, name_label, notes_label, desc_label, plot_label, axis_label, scale_label, min_label, max_label, fill_label, **kwargs)
    370         manual_org = False if manual_org is None else manual_org
    371         temporary_file_list = not temporary_file_list
--> 372         self.files = pysat.Files(self, manual_org=manual_org,
    373                                  directory_format=self.directory_format,
    374                                  update_files=update_files,

~/code/core/pysat/pysat/_files.py in __init__(self, sat, manual_org, directory_format, update_files, file_format, write_to_disk, ignore_empty_files)
    180             else:
    181                 # couldn't find stored info, load file list and then store
--> 182                 self.refresh()
    183 
    184     def __repr__(self):

~/code/core/pysat/pysat/_files.py in refresh(self)
    373         logger.info(output_str)
    374 
--> 375         info = self._sat._list_files_rtn(tag=self._sat.tag,
    376                                          inst_id=self._sat.inst_id,
    377                                          data_path=self.data_path,

~/code/core/pysat/pysat/instruments/methods/general.py in list_files(tag, inst_id, data_path, format_str, supported_tags, fake_daily_files_from_monthly, two_digit_year_break, delimiter)
     83             format_str = supported_tags[inst_id][tag]
     84         except KeyError as kerr:
---> 85             raise ValueError(' '.join(('Unknown inst_id or tag:',
     86                                        str(kerr))))
     87 

ValueError: Unknown inst_id or tag: 'nmax'
```

I'm a little surprised this wasn't caught in the unit tests.  We might be bypassing something somewhere when the instrument tests are constucted.