### PR TITLE
STY: changed name of default to preprocess

### DIFF
--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -93,7 +93,7 @@ def init(self):
     return
 
 
-def default(self):
+def preprocess(self):
     """Apply C/NOFS IVM default attributes
 
     Note

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -89,9 +89,8 @@ def init(self):
     return
 
 
-def default(self, keep_original_names=False):
-    """Default routine to be applied when loading data. Adjusts epoch timestamps
-    to datetimes and removes variable preambles.
+def preprocess(self, keep_original_names=False):
+    """Adjusts epoch timestamps to datetimes and removes variable preambles.
 
     Parameters
     ----------

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -92,9 +92,8 @@ def init(self):
     return
 
 
-def default(self, keep_original_names=False):
-    """Default routine to be applied when loading data. Adjusts epoch timestamps
-    to datetimes and removes variable preambles.
+def preprocess(self, keep_original_names=False):
+    """Adjusts epoch timestamps to datetimes and removes variable preambles.
 
     Parameters
     ----------

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -94,9 +94,8 @@ def init(self):
     return
 
 
-def default(self, keep_original_names=False):
-    """Default routine to be applied when loading data. Removes variable
-    preambles.
+def preprocess(self, keep_original_names=False):
+    """Removes variable preambles.
 
     Parameters
     ----------

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -105,9 +105,8 @@ def init(self):
     return
 
 
-def default(self, keep_original_names=False):
-    """Default routine to be applied when loading data.  Adjusts epoch
-    timestamps to datetimes and removes variable preambles.
+def preprocess(self, keep_original_names=False):
+    """Adjusts epoch timestamps to datetimes and removes variable preambles.
 
     Parameters
     ----------


### PR DESCRIPTION
Changed name of Instrument method `default` to `preprocess` in accordance with new pysat standards (PR https://github.com/pysat/pysat/pull/626).

Will need the pysat PR to be merged and #26 to be merged before tests will pass.