### PR TITLE
Update to use `file_cadance` kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [next version] - 2020-09-14
+- Updated Instruments and routines to conform with changes made for pysat 3.0
 - New Instruments
   - GOLD Nmax
 

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -19,7 +19,7 @@ from pysat.utils import files as futils
 from pysat.instruments.methods import general
 
 
-def load(fnames, tag=None, inst_id=None, file_cadance=dt.timedelta(days=1),
+def load(fnames, tag=None, inst_id=None, file_cadence=dt.timedelta(days=1),
          flatten_twod=True):
     """Load NASA CDAWeb CDF files.
 
@@ -31,10 +31,10 @@ def load(fnames, tag=None, inst_id=None, file_cadance=dt.timedelta(days=1),
         tag or None (default=None)
     inst_id : str or NoneType
         satellite id or None (default=None)
-    file_cadance : dt.timedelta or pds.DateOffset
-        pysat assumes a daily file cadance, but some instrument data file
+    file_cadence : dt.timedelta or pds.DateOffset
+        pysat assumes a daily file cadence, but some instrument data file
         contain longer periods of time.  This parameter allows the specification
-        of regular file cadances greater than or equal to a day (e.g., weekly,
+        of regular file cadences greater than or equal to a day (e.g., weekly,
         monthly, or yearly). (default=dt.timedelta(days=1))
     flatted_twod : bool
         Flattens 2D data into different columns of root DataFrame rather
@@ -76,7 +76,7 @@ def load(fnames, tag=None, inst_id=None, file_cadance=dt.timedelta(days=1),
         # need modification
         ldata = []
         for lfname in fnames:
-            if not general.is_daily_file_cadance(file_cadance):
+            if not general.is_daily_file_cadence(file_cadence):
                 # Parse out date from filename
                 fname = lfname[0:-11]
 

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -13,8 +13,10 @@ import sys
 from bs4 import BeautifulSoup
 import pandas as pds
 
+import pysatCDF
 from pysat import logger
 from pysat.utils import files as futils
+from pysat.instruments.methods import general
 
 
 def load(fnames, tag=None, inst_id=None, file_cadance=dt.timedelta(days=1),
@@ -65,8 +67,6 @@ def load(fnames, tag=None, inst_id=None, file_cadance=dt.timedelta(days=1),
 
     """
 
-    import pysatCDF
-
     if len(fnames) <= 0:
         return pds.DataFrame(None), None
     else:
@@ -76,7 +76,7 @@ def load(fnames, tag=None, inst_id=None, file_cadance=dt.timedelta(days=1),
         # need modification
         ldata = []
         for lfname in fnames:
-            if file_cadance.days > 1:
+            if not general.is_daily_file_cadance(file_cadance):
                 # Parse out date from filename
                 fname = lfname[0:-11]
 

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -32,7 +32,7 @@ def load(fnames, tag=None, inst_id=None, file_cadence=dt.timedelta(days=1),
     inst_id : str or NoneType
         satellite id or None (default=None)
     file_cadence : dt.timedelta or pds.DateOffset
-        pysat assumes a daily file cadence, but some instrument data file
+        pysat assumes a daily file cadence, but some instrument data files
         contain longer periods of time.  This parameter allows the specification
         of regular file cadences greater than or equal to a day (e.g., weekly,
         monthly, or yearly). (default=dt.timedelta(days=1))

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -65,7 +65,7 @@ platform = 'omni'
 name = 'hro'
 tags = {'1min': '1-minute time averaged data',
         '5min': '5-minute time averaged data'}
-inst_ids = {'': ['5min']}
+inst_ids = {'': [tag for tags.keys()]}
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes
@@ -126,26 +126,24 @@ def clean(self):
 # Use the default CDAWeb and pysat methods
 
 # Set the list_files routine
-fname1 = 'omni_hro_1min_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf'
-fname5 = 'omni_hro_5min_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf'
-supported_tags = {'': {'1min': fname1, '5min': fname5}}
+fname = ''.join(['omni_hro_{tag:s}_{{year:4d}}{{month:02d}}{{day:02d}}_',
+                 'v{{version:02d}}.cdf'])
+supported_tags = {inst_id: {tag: fname.format(tag=tag) for tag in tags.keys()}
+                  for inst_id in inst_ids.keys()}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags,
-                               fake_daily_files_from_monthly=True)
+                               file_cadance=pds.DateOffset(months=1))
 
 # Set the load routine
-load = functools.partial(cdw.load, fake_daily_files_from_monthly=True)
+load = functools.partial(cdw.load, file_cadance=pds.DateOffset(months=1))
 
 # Set the download routine
-basic_tag1 = {'remote_dir': '/pub/data/omni/omni_cdaweb/hro_1min/{year:4d}/',
-              'fname': fname1}
-basic_tag5 = {'remote_dir': '/pub/data/omni/omni_cdaweb/hro_5min/{year:4d}/',
-              'fname': fname5}
-download_tags = {'': {'1min': basic_tag1,
-                      '5min': basic_tag5}}
-download = functools.partial(cdw.download,
-                             supported_tags=download_tags,
-                             fake_daily_files_from_monthly=True)
+remote_dir = '/pub/data/omni/omni_cdaweb/hro_{tag:s}/{{year:4d}}/'
+download_tags = {inst_id: {tag: {'remote_dir': remote_dir.format(tag),
+                                 'fname': suppoorted_tags[inst_id][tag]}
+                           for tag in tags.keys()}
+                 for inst_id in inst_ids.keys()}
+download = functools.partial(cdw.download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
 list_remote_files = functools.partial(cdw.list_remote_files,

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -65,7 +65,7 @@ platform = 'omni'
 name = 'hro'
 tags = {'1min': '1-minute time averaged data',
         '5min': '5-minute time averaged data'}
-inst_ids = {'': [tag for tags.keys()]}
+inst_ids = {'': [tag for tag in tags.keys()]}
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes
@@ -139,9 +139,9 @@ load = functools.partial(cdw.load, file_cadance=pds.DateOffset(months=1))
 
 # Set the download routine
 remote_dir = '/pub/data/omni/omni_cdaweb/hro_{tag:s}/{{year:4d}}/'
-download_tags = {inst_id: {tag: {'remote_dir': remote_dir.format(tag),
-                                 'fname': suppoorted_tags[inst_id][tag]}
-                           for tag in tags.keys()}
+download_tags = {inst_id: {tag: {'remote_dir': remote_dir.format(tag=tag),
+                                 'fname': supported_tags[inst_id][tag]}
+                           for tag in inst_ids[inst_id]}
                  for inst_id in inst_ids.keys()}
 download = functools.partial(cdw.download, supported_tags=download_tags)
 

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -132,10 +132,10 @@ supported_tags = {inst_id: {tag: fname.format(tag=tag) for tag in tags.keys()}
                   for inst_id in inst_ids.keys()}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags,
-                               file_cadance=pds.DateOffset(months=1))
+                               file_cadence=pds.DateOffset(months=1))
 
 # Set the load routine
-load = functools.partial(cdw.load, file_cadance=pds.DateOffset(months=1))
+load = functools.partial(cdw.load, file_cadence=pds.DateOffset(months=1))
 
 # Set the download routine
 remote_dir = '/pub/data/omni/omni_cdaweb/hro_{tag:s}/{{year:4d}}/'

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -116,18 +116,17 @@ def clean(self):
 # Set the list_files routine
 fname = ''.join(('gold_l2_{tag:s}_{{year:04d}}_{{day:03d}}_v{{version:02d}}',
                  '_r{{revision:02d}}_c{{cycle:02d}}.nc'))
-supported_tags = {'': {}}
-for tag in inst_ids['']:
-    supported_tags[''][tag] = fname.format(tag=tag)
+supported_tags = {inst_id: {tag: fname.format(tag=tag) for tag in tags.keys()}
+                  for inst_id in inst_ids.keys()}
 list_files = functools.partial(ps_gen.list_files,
                                supported_tags=supported_tags)
 
 # Set the download routine
-download_tags = {'': {}}
-for tag in inst_ids['']:
-    download_tags[''][tag] = {'remote_dir': ''.join(('/pub/data/gold/level2/',
-                                                     tag, '/{year:4d}/')),
-                              'fname': fname.format(tag=tag)}
+download_tags = {inst_id:
+                 {tag: {'remote_dir': ''.join(('/pub/data/gold/level2/', tag,
+                                               '/{year:4d}/')),
+                        'fname': supported_tags[''][tag]}
+                  for tag in tags.keys()} for inst_id in inst_ids.keys()}
 download = functools.partial(cdw.download, supported_tags=download_tags)
 
 # Set the list_remote_files routine

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -39,6 +39,7 @@ Warnings
 
 import datetime as dt
 import functools
+import pandas as pds
 import warnings
 
 from pysat import logger

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -109,10 +109,10 @@ fname = 'timed_l3a_see_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf'
 supported_tags = {'': {'': fname}}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags,
-                               file_cadance=pds.DateOffset(months=1))
+                               file_cadence=pds.DateOffset(months=1))
 
 # Set the load routine
-load = functools.partial(cdw.load, file_cadance=pds.DateOffset(months=1))
+load = functools.partial(cdw.load, file_cadence=pds.DateOffset(months=1))
 
 # Set the download routine
 basic_tag = {'remote_dir': ''.join(('/pub/data/timed/see/data/level3a_cdf',

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -51,7 +51,7 @@ from pysatNASA.instruments.methods import cdaweb as cdw
 platform = 'timed'
 name = 'see'
 tags = {'': ''}
-inst_ids = {'': ['']}
+inst_ids = {'': [tag for tag in tags.keys()]}
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes
@@ -108,10 +108,10 @@ fname = 'timed_l3a_see_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf'
 supported_tags = {'': {'': fname}}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags,
-                               fake_daily_files_from_monthly=True)
+                               file_cadance=pds.DateOffset(months=1))
 
 # Set the load routine
-load = functools.partial(cdw.load, fake_daily_files_from_monthly=True)
+load = functools.partial(cdw.load, file_cadance=pds.DateOffset(months=1))
 
 # Set the download routine
 basic_tag = {'remote_dir': ''.join(('/pub/data/timed/see/data/level3a_cdf',


### PR DESCRIPTION
Changed `fake_daily_files_from_monthly` kwarg to `fille_cadance`, which provides more adaptive instrument support.  Also fixed some bugs in OMNI HRO and removed unused kwargs in cdaweb routines.  Requires pysat PR https://github.com/pysat/pysat/pull/629