### PR TITLE
BUG: Addresses issue with remote file names

### DIFF
--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -234,7 +234,7 @@ list_files = functools.partial(mm_gen.list_files,
 
 # Set the download routine
 dirstr1 = '/pub/data/icon/l2/l2-1_mighti-{{id:s}}_los-wind-{color:s}/'
-dirstr2 = '/pub/data/icon/l2/l2-2_mighti-vector-wind-{color:s}/'
+dirstr2 = '/pub/data/icon/l2/l2-2_mighti_vector-wind-{color:s}/'
 dirstr3 = '/pub/data/icon/l2/l2-3_mighti-{id:s}_temperature/'
 dirnames = {'los_wind_green': dirstr1.format(color='green'),
             'los_wind_red': dirstr1.format(color='red'),

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -691,6 +691,15 @@ def list_remote_files(tag=None, inst_id=None, start=None, stop=None,
     search_dict = futils.construct_searchstring_from_format(format_str)
     targets = [x.strip('?') for x in search_dict['string_blocks'] if len(x) > 0]
 
+    # Remove any additional '?' characters that the user may have supplied
+    new_targets = []
+    for target in targets:
+        tstrs = target.split('?')
+        for tstr in tstrs:
+            if tstr != '':
+                new_targets.append(tstr)
+    targets = new_targets
+
     remote_dirs = []
     for level in range(n_layers + 1):
         remote_dirs.append([])
@@ -748,7 +757,6 @@ def list_remote_files(tag=None, inst_id=None, start=None, stop=None,
     else:
         stored = futils.parse_delimited_filenames(full_files, format_str,
                                                   delimiter)
-
     # Process the parsed filenames and return a properly formatted Series
     stored_list = futils.process_parsed_filenames(stored, two_digit_year_break)
 

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -115,7 +115,7 @@ def clean(self):
 
 # Set the list_files routine
 fname = ''.join(('gold_l2_{tag:s}_{{year:04d}}_{{day:03d}}_v{{version:02d}}',
-                 '_r{{revision:02d}}_c{{cycle:02d}}.nc'))
+                 '_r{{revision:02d}}_c??.nc'))
 supported_tags = {inst_id: {tag: fname.format(tag=tag) for tag in tags.keys()}
                   for inst_id in inst_ids.keys()}
 list_files = functools.partial(ps_gen.list_files,

--- a/pysatNASA/tests/test_instruments.py
+++ b/pysatNASA/tests/test_instruments.py
@@ -50,8 +50,8 @@ class TestInstruments(InstTestClass):
         # Make sure to use a temporary directory so that the user's setup is not
         # altered
         self.tempdir = tempfile.TemporaryDirectory()
-        self.saved_path = pysat.data_dir
-        pysat.utils.set_data_dir(self.tempdir.name, store=False)
+        self.saved_path = pysat.params['data_dirs']
+        pysat.params.data['data_dirs'] = [self.tempdir.name]
         # Developers for instrument libraries should update the following line
         # to point to their own subpackage location, e.g.,
         # self.inst_loc = mypackage.instruments
@@ -59,6 +59,6 @@ class TestInstruments(InstTestClass):
 
     def teardown_class(self):
         """Runs once to clean up testing from this class."""
-        pysat.utils.set_data_dir(self.saved_path, store=False)
+        pysat.params.data['data_dirs'] = self.saved_path
         self.tempdir.cleanup()
         del self.inst_loc, self.saved_path, self.tempdir


### PR DESCRIPTION
See issue: https://github.com/pysat/pysat/issues/566

```
In [1]: import datetime as dt 
   ...: import pysat 
   ...: import pysatNASA 
   ...: nmax = pysat.Instrument(inst_module=pysatNASA.instruments.ses14_gold, 
   ...:                         strict_time_flag=False, tag='nmax')                                                                                                                                                          
pysat WARNING: Time stamps may be non-unique because Channel A and B are different instruments.  An upgrade to the pysat.Constellation object is required to solve this issue. See pysat issue #614 for more info.

In [2]: nmax.remote_file_list(start=dt.datetime(2020, 3, 1), stop=dt.datetime(2020, 3, 31))                                                                                                                                  
Out[2]: 
2020-03-01    gold_l2_nmax_2020_061_v01_r01_c01.nc
2020-03-02    gold_l2_nmax_2020_062_v01_r01_c01.nc
2020-03-03    gold_l2_nmax_2020_063_v01_r01_c01.nc
2020-03-04    gold_l2_nmax_2020_064_v01_r01_c01.nc
2020-03-05    gold_l2_nmax_2020_065_v01_r01_c01.nc
2020-03-06    gold_l2_nmax_2020_066_v01_r01_c01.nc
2020-03-07    gold_l2_nmax_2020_067_v01_r01_c01.nc
2020-03-08    gold_l2_nmax_2020_068_v01_r01_c01.nc
2020-03-09    gold_l2_nmax_2020_069_v01_r01_c01.nc
2020-03-10    gold_l2_nmax_2020_070_v01_r01_c02.nc
2020-03-11    gold_l2_nmax_2020_071_v01_r01_c02.nc
2020-03-12    gold_l2_nmax_2020_072_v01_r01_c02.nc
2020-03-13    gold_l2_nmax_2020_073_v01_r01_c02.nc
2020-03-14    gold_l2_nmax_2020_074_v01_r01_c02.nc
2020-03-15    gold_l2_nmax_2020_075_v01_r01_c02.nc
2020-03-16    gold_l2_nmax_2020_076_v01_r01_c02.nc
2020-03-17    gold_l2_nmax_2020_077_v01_r01_c02.nc
2020-03-18    gold_l2_nmax_2020_078_v01_r01_c02.nc
2020-03-19    gold_l2_nmax_2020_079_v01_r01_c02.nc
2020-03-20    gold_l2_nmax_2020_080_v01_r01_c02.nc
2020-03-21    gold_l2_nmax_2020_081_v01_r01_c02.nc
2020-03-22    gold_l2_nmax_2020_082_v01_r01_c02.nc
2020-03-23    gold_l2_nmax_2020_083_v01_r01_c02.nc
2020-03-24    gold_l2_nmax_2020_084_v01_r01_c03.nc
2020-03-25    gold_l2_nmax_2020_085_v01_r01_c02.nc
2020-03-26    gold_l2_nmax_2020_086_v01_r01_c02.nc
2020-03-27    gold_l2_nmax_2020_087_v01_r01_c02.nc
2020-03-28    gold_l2_nmax_2020_088_v01_r01_c02.nc
2020-03-29    gold_l2_nmax_2020_089_v01_r01_c02.nc
2020-03-30    gold_l2_nmax_2020_090_v01_r01_c02.nc
2020-03-31    gold_l2_nmax_2020_091_v01_r01_c02.nc
dtype: object
```

where the filename for the data set is:

```
fname = ''.join(('gold_l2_{tag:s}_{{year:04d}}_{{day:03d}}_v{{version:02d}}',
                 '_r{{revision:02d}}_c??.nc'))
```