### PR TITLE
BUG: Added with statement to file open

### DIFF
--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -585,7 +585,8 @@ def download(date_array, tag=None, inst_id=None, supported_tags=None,
                                     fname))
             req = requests.get(remote_path)
             if req.status_code != 404:
-                open(saved_local_fname, 'wb').write(req.content)
+                with open(saved_local_fname, 'wb') as open_f:
+                    open_f.write(req.content)
                 logger.info('Finished.')
             else:
                 logger.info(' '.join(('File not available for',


### PR DESCRIPTION
Review of test logs in pysat v2.3 revealed:
```
ResourceWarning: Enable tracemalloc to get the object allocation traceback
1733/home/travis/build/pysat/pysat/pysat/instruments/methods/nasa_cdaweb.py:339: ResourceWarning: unclosed file <_io.BufferedWriter name='/tmp/tmpe4lbgacq/timed/saber/timed_l2av207_saber_201901010209_v01.cdf'>
1734  open(saved_local_fname, 'wb').write(req.content)
1735
```

I added a with statement to the open command to ensure the file is closed.