### PR TITLE
BUG: remote_file_list for unspecified start/stop dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated Instruments and routines to conform with changes made for pysat 3.0
 - New Instruments
   - GOLD Nmax
+- Bug Fixes
+  - remote_file_list error if start/stop dates unspecified
 
 ## [0.0.1] - 2020-08-13
 - initial port of existing routines from pysat

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -709,7 +709,9 @@ def list_remote_files(tag=None, inst_id=None, start=None, stop=None,
     full_files = []
 
     if start is None and stop is None:
-        url_list = [remote_url]
+        # Use the topmost directory without variables
+        url_list = ['/'.join((remote_url,
+                              search_dir['string_blocks'][0]))]
     elif start is not None:
         stop = dt.datetime.now() if (stop is None) else stop
 

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -670,9 +670,6 @@ def list_remote_files(tag=None, inst_id=None, start=None, stop=None,
     except KeyError:
         raise ValueError('inst_id / tag combo unknown.')
 
-    # Path to relevant file on CDAWeb
-    remote_url = remote_url
-
     # Naming scheme for files on the CDAWeb server
     format_str = '/'.join((inst_dict['remote_dir'].strip('/'),
                            inst_dict['fname']))

--- a/pysatNASA/tests/test_methods_cdaweb.py
+++ b/pysatNASA/tests/test_methods_cdaweb.py
@@ -3,6 +3,7 @@ import requests
 
 import pytest
 
+import pysat
 import pysatNASA
 from pysatNASA.instruments.methods import cdaweb as cdw
 
@@ -61,3 +62,10 @@ class TestCDAWeb():
                                   tag=self.kwargs['tag'],
                                   inst_id=self.kwargs['inst_id'])
         assert str(excinfo.value).find(err_msg) >= 0
+
+    def test_remote_file_list_all(self):
+        """Test that remote_file_list works if start/stop dates unspecified"""
+        self.module = pysatNASA.instruments.cnofs_plp
+        self.test_inst = pysat.Instrument(inst_module=self.module)
+        files = self.test_inst.remote_file_list()
+        assert len(files) > 0


### PR DESCRIPTION
Addresses #51.

When the start/stop notation was added to `remote_file_list`, the url to search was not updated to include the subdirectory.  The code would then search the front page of cdaweb for files and fail. Note this affects a number of other functions that call this, including `remote_date_range` and `download_updated_files`.  

The end-to-end unit tests from pysat only check this with the start/stop date option.  Since this affects custom code, a test is added to call on plp data (chosen as the data set is fairly small).

