### PR TITLE
STY: docstrings and core code (2 of 3)

### DIFF
--- a/pysatNASA/constellations/__init__.py
+++ b/pysatNASA/constellations/__init__.py
@@ -1,3 +1,10 @@
+"""Interface for pysatNASA to manage and analyze multiple pysat instruments.
+
+Each instrument is contained within a subpackage of the pysatNASA.instruments
+package.
+"""
+
+
 __all__ = ['de2', 'icon']
 
 for const in __all__:

--- a/pysatNASA/constellations/de2.py
+++ b/pysatNASA/constellations/de2.py
@@ -1,9 +1,8 @@
+"""Creates a constellation from the NASA DE2 satellite platform."""
+
 import pysat
 
 from pysatNASA import instruments
-"""
-Creates a constellation from the NASA DE2 satellite platform
-"""
 
 
 lang = pysat.Instrument(inst_module=instruments.de2_lang)

--- a/pysatNASA/constellations/icon.py
+++ b/pysatNASA/constellations/icon.py
@@ -1,6 +1,4 @@
-"""
-Creates a constellation from NASA the ICON satellite platform
-"""
+"""Creates a constellation from NASA the ICON satellite platform."""
 
 import pysat
 

--- a/pysatNASA/constellations/icon.py
+++ b/pysatNASA/constellations/icon.py
@@ -2,7 +2,10 @@
 
 import pysat
 
-from pysatNASA.instruments import icon_ivm, icon_euv, icon_fuv, icon_mighti
+from pysatNASA.instruments import icon_euv
+from pysatNASA.instruments import icon_fuv
+from pysatNASA.instruments import icon_ivm
+from pysatNASA.instruments import icon_mighti
 
 instruments = list()
 

--- a/pysatNASA/instruments/__init__.py
+++ b/pysatNASA/instruments/__init__.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Collection of instruments for the pysatNASA library.
+
+Each instrument is contained within a subpackage of this set.
+
+"""
+
 __all__ = ['cnofs_ivm', 'cnofs_plp', 'cnofs_vefi',
            'de2_lang', 'de2_nacs', 'de2_rpa', 'de2_wats',
            'formosat1_ivm',

--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -57,11 +57,11 @@ import functools
 
 import numpy as np
 
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
-from pysatNASA.instruments.methods import cnofs as mm_cnofs
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import cnofs as mm_cnofs
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -58,11 +58,11 @@ import datetime as dt
 import functools
 import numpy as np
 
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
-from pysatNASA.instruments.methods import cnofs as mm_cnofs
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import cnofs as mm_cnofs
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -60,11 +60,11 @@ import datetime as dt
 import functools
 import numpy as np
 
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
-from pysatNASA.instruments.methods import cnofs as mm_cnofs
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import cnofs as mm_cnofs
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -57,11 +57,11 @@ import datetime as dt
 import functools
 import warnings
 
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
-from pysatNASA.instruments.methods import de2 as mm_de2
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import de2 as mm_de2
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -80,11 +80,11 @@ import datetime as dt
 import functools
 import warnings
 
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
-from pysatNASA.instruments.methods import de2 as mm_de2
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import de2 as mm_de2
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -65,11 +65,11 @@ import datetime as dt
 import functools
 import warnings
 
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
-from pysatNASA.instruments.methods import de2 as mm_de2
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import de2 as mm_de2
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -76,11 +76,11 @@ import datetime as dt
 import functools
 import warnings
 
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
-from pysatNASA.instruments.methods import de2 as mm_de2
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import de2 as mm_de2
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/formosat1_ivm.py
+++ b/pysatNASA/instruments/formosat1_ivm.py
@@ -24,8 +24,8 @@ import datetime as dt
 import functools
 import warnings
 
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -45,8 +45,8 @@ import datetime as dt
 import functools
 
 import pysat
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import icon as mm_icon

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -41,8 +41,8 @@ import functools
 import numpy as np
 
 import pysat
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import icon as mm_icon

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -60,8 +60,8 @@ import datetime as dt
 import functools
 
 import pysat
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import icon as mm_icon

--- a/pysatNASA/instruments/iss_fpmu.py
+++ b/pysatNASA/instruments/iss_fpmu.py
@@ -26,8 +26,8 @@ import datetime as dt
 import functools
 import numpy as np
 
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 

--- a/pysatNASA/instruments/methods/_cdf.py
+++ b/pysatNASA/instruments/methods/_cdf.py
@@ -37,8 +37,8 @@ def convert_ndimensional(data, index=None, columns=None):
                          columns=columns, index=index)
 
 
-class CDF():
-    """cdflib wrapper for loading time series data
+class CDF(object):
+    """Wraps cdflib for loading time series data.
 
     Loading routines borrow heavily from pyspedas's cdf_to_tplot function
 

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -12,9 +12,9 @@ import requests
 
 from bs4 import BeautifulSoup
 
+from pysat.instruments.methods import general
 from pysat import logger
 from pysat.utils import files as futils
-from pysat.instruments.methods import general
 from pysatNASA.instruments.methods import CDF
 
 

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -55,8 +55,8 @@ import pandas as pds
 import scipy.stats as stats
 import warnings
 
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -38,12 +38,12 @@ import datetime as dt
 import functools
 import warnings
 
-from pysat import logger
 from pysat.instruments.methods import general as ps_gen
+from pysat import logger
 from pysat.utils import load_netcdf4
 
-from pysatNASA.instruments.methods import gold as mm_gold
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import gold as mm_gold
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/templates/template_cdaweb_instrument.py
+++ b/pysatNASA/instruments/templates/template_cdaweb_instrument.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-"""This is a template for a pysat.Instrument support file that
-utilizes CDAWeb methods. Copy and modify this file as needed when adding a
-new Instrument to pysat.
+"""Template for a pysat.Instrument support file that utilizes CDAWeb methods.
+
+Copy and modify this file as needed when adding a new Instrument to pysat.
 
 This is a good area to introduce the instrument, provide background
 on the mission, operations, instrumenation, and measurements.
@@ -127,8 +127,8 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 # code should be defined below as needed
-def default(self):
-    """Default customization function.
+def preprocess(self):
+    """Perform standard preprocessing.
 
     This routine is automatically applied to the Instrument object
     on every load by the pysat nanokernel (first in queue).
@@ -145,7 +145,7 @@ def default(self):
 
 # code should be defined below as needed
 def clean(inst):
-    """Routine to return PLATFORM/NAME data cleaned to the specified level
+    """Return `platform_name` data to the specified level..
 
     Cleaning level is specified in inst.clean_level and pysat
     will accept user input for several strings. The clean_level is

--- a/pysatNASA/instruments/templates/template_cdaweb_instrument.py
+++ b/pysatNASA/instruments/templates/template_cdaweb_instrument.py
@@ -47,8 +47,8 @@ import datetime as dt
 import functools
 
 # CDAWeb methods prewritten for pysat
-from pysat.instruments.methods import nasa_cdaweb as cdw
 from pysat.instruments.methods import general as mm_gen
+from pysatNASA.instruments.methods import cdaweb as cdw
 
 # the platform and name strings associated with this instrument
 # need to be defined at the top level

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -51,8 +51,8 @@ import functools
 import warnings
 
 # CDAWeb methods prewritten for pysat
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -42,8 +42,8 @@ import functools
 import pandas as pds
 import warnings
 
-from pysat import logger
 from pysat.instruments.methods import general as mm_gen
+from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 

--- a/pysatNASA/tests/test_instruments.py
+++ b/pysatNASA/tests/test_instruments.py
@@ -13,9 +13,10 @@ import pytest
 import pysat
 # Make sure to import your instrument library here
 import pysatNASA
+
 # Import the test classes from pysat
-from pysat.utils import generate_instrument_list
 from pysat.tests.instrument_test_class import InstTestClass
+from pysat.utils import generate_instrument_list
 
 
 # Developers for instrument libraries should update the following line to

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,15 @@
 # Copyright (C) 2020, Authors
 # Full license can be found in License.md and AUTHORS.md
 # -----------------------------------------------------------------------------
+"""Setup routines for pysatNASA.
+
+Note
+----
+Package metadata stored in setup.cfg
+
+"""
 
 from setuptools import setup
-
-# Package metadata stored in setup.cfg
 
 # Run setup
 setup()


### PR DESCRIPTION
# Description

Updates docstring style and import order in preparation for flake8-docstrings and hacking tests.

Following pull will be the instrument library docstrings, where the bulk of the changes are.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local run of flake8.

## Test Configuration
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.2
* `flake8-docstrings` and `hacking`

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [na] Add a note to ``CHANGELOG.md``, summarizing the changes (will update with final pull)
- [na] Update zenodo.json file for new code contributors
