### PR TITLE
DOC/STY: docstrings for instrument modules (3 of 3)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
 
     - name: Test PEP8 compliance
-      run: flake8 . --count --select=E,F,W --show-source --statistics
+      run: flake8 . --count --select=D,E,F,H,W --show-source --statistics
 
     - name: Evaluate complexity
       run: flake8 . --count --exit-zero --max-complexity=10 --statistics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.0.4] - 2021-XX-XX
+* Include flake8 linting of docstrings and style in Github Actions
+
 ## [0.0.3] - 2021-06-17
 * Include Windows tests in Github Actions
 * Bug Fixes

--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Ion Velocity Meter (IVM) onboard the Communication
+"""Module for the C/NOFS IVM instrument.
+
+Supports the Ion Velocity Meter (IVM) onboard the Communication
 and Navigation Outage Forecasting System (C/NOFS) satellite, part
 of the Coupled Ion Netural Dynamics Investigation (CINDI). Downloads
 data from the NASA Coordinated Data Analysis Web (CDAWeb) in CDF
@@ -81,7 +83,7 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -95,7 +97,7 @@ def init(self):
 
 
 def preprocess(self):
-    """Apply C/NOFS IVM default attributes
+    """Apply C/NOFS IVM default attributes.
 
     Note
     ----
@@ -109,7 +111,7 @@ def preprocess(self):
 
 
 def clean(self):
-    """Routine to return C/NOFS IVM data cleaned to the specified level
+    """Clean C/NOFS IVM data to the specified level.
 
     Note
     ----

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Planar Langmuir Probe (PLP) onboard the Communication
+"""Module for the C/NOFS PLP innstrument.
+
+Supports the Planar Langmuir Probe (PLP) onboard the Communication
 and Navigation Outage Forecasting System (C/NOFS) satellite. Downloads
 data from the NASA Coordinated Data Analysis Web (CDAWeb).
 
@@ -82,7 +84,7 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -96,7 +98,7 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return C/NOFS PLP data cleaned to the specified level
+    """Clean C/NOFS PLP data to the specified level.
 
     Note
     ----

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Module for the C/NOFS PLP innstrument.
+"""Module for the C/NOFS PLP instrument.
 
 Supports the Planar Langmuir Probe (PLP) onboard the Communication
 and Navigation Outage Forecasting System (C/NOFS) satellite. Downloads

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Vector Electric Field Instrument (VEFI)
+"""Module for the C/NOFS VEFI instrument.
+
+Supports the Vector Electric Field Instrument (VEFI)
 onboard the Communication and Navigation Outage Forecasting
 System (C/NOFS) satellite. Downloads data from the
 NASA Coordinated Data Analysis Web (CDAWeb).
@@ -84,7 +86,7 @@ _test_dates = {'': {'dc_b': dt.datetime(2009, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -98,7 +100,7 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return VEFI data cleaned to the specified level
+    """Clean VEFI data to the specified level.
 
     Note
     ----

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Langmuir Probe (LANG) instrument on
-Dynamics Explorer 2 (DE2).
+"""Module for the DE2 LANG instrument.
+
+Supports the Langmuir Probe (LANG) instrument on Dynamics Explorer 2 (DE2).
 
 From CDAWeb:
 
@@ -81,7 +82,7 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -94,7 +95,7 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return DE2 LANG data cleaned to the specified level
+    """Clean DE2 LANG data to the specified level.
 
     Note
     ----

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Neutral Atmosphere Composition Spectrometer (NACS) instrument
+"""The DE2 NACS instrument.
+
+Supports the Neutral Atmosphere Composition Spectrometer (NACS) instrument
 on Dynamics Explorer 2 (DE2).
 
 From CDAWeb:
@@ -104,7 +106,7 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -117,7 +119,7 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return DE2 NACS data cleaned to the specified level
+    """Clean DE2 NACS data to the specified level.
 
     Note
     ----

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-"""Supports the Retarding Potential Analyzer (RPA) instrument on
-Dynamics Explorer 2 (DE2).
+"""Module for the DE2 RPA instrument.
+
+Supports the Retarding Potential Analyzer (RPA) instrument on Dynamics
+Explorer 2 (DE2).
 
 From CDAWeb:
 
@@ -89,7 +91,7 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -102,7 +104,7 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return DE2 RPA data cleaned to the specified level
+    """Clean DE2 RPA data to the specified level.
 
     Note
     ----

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Wind and Temperature Spectrometer (WATS) instrument on
+"""Module for the DE2 WATS instrument.
+
+Supports the Wind and Temperature Spectrometer (WATS) instrument on
 Dynamics Explorer 2 (DE2).
 
 From CDAWeb:
@@ -100,7 +102,7 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -113,7 +115,7 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return DE2 LANG data cleaned to the specified level
+    """Clean DE2 LANG data to the specified level.
 
     Note
     ----

--- a/pysatNASA/instruments/formosat1_ivm.py
+++ b/pysatNASA/instruments/formosat1_ivm.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Ion Velocity Meter (IVM) onboard the Formosat-1 (formerly
+"""Module for the ICON EUV instrument.
+
+Supports the Ion Velocity Meter (IVM) onboard the Formosat-1 (formerly
 ROCSAT-1) mission. Downloads data from the NASA Coordinated Data Analysis
 Web (CDAWeb).
 
@@ -47,7 +49,7 @@ _test_dates = {'': {'': dt.datetime(2002, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -73,7 +75,7 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return FORMOSAT-1 IVM data cleaned to the specified level
+    """Clean FORMOSAT-1 IVM data to the specified level.
 
     Note
     ----

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -158,7 +158,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None, keep_original_names=False):
-    """Load ICON EUV data into xarray.Dataset object and pysat.Meta objects.
+    """Load ICON EUV data into `xarray.Dataset` object and `pysat.Meta` objects.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -158,7 +158,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None, keep_original_names=False):
-    """Load ICON EUV data using pysat into xarray.
+    """Load ICON EUV data into xarray.Dataset object and pysat.Meta objects.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Extreme Ultraviolet (EUV) imager onboard the Ionospheric
+"""Module for the ICON EUV instrument.
+
+Supports the Extreme Ultraviolet (EUV) imager onboard the Ionospheric
 CONnection Explorer (ICON) satellite.  Accesses local data in
 netCDF format.
 
@@ -71,7 +73,7 @@ _test_dates = {'': {'': dt.datetime(2020, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -91,7 +93,7 @@ def init(self):
 
 
 def preprocess(self, keep_original_names=False):
-    """Adjusts epoch timestamps to datetimes and removes variable preambles.
+    """Adjust epoch timestamps to datetimes and remove variable preambles.
 
     Parameters
     ----------
@@ -108,7 +110,7 @@ def preprocess(self, keep_original_names=False):
 
 
 def clean(self):
-    """Provides data cleaning based upon clean_level.
+    """Clean ICON EUV data to the specified level.
 
     Note
     ----
@@ -156,7 +158,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None, keep_original_names=False):
-    """Loads ICON EUV data using pysat into pandas.
+    """Load ICON EUV data using pysat into xarray.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Far Ultraviolet (FUV) imager onboard the Ionospheric
+"""Module for the ICON FUV instrument.
+
+Supports the Far Ultraviolet (FUV) imager onboard the Ionospheric
 CONnection Explorer (ICON) satellite.  Accesses local data in
 netCDF format.
 
@@ -75,7 +77,7 @@ _test_dates = {'': {kk: dt.datetime(2020, 1, 1) for kk in tags.keys()}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -95,7 +97,7 @@ def init(self):
 
 
 def preprocess(self, keep_original_names=False):
-    """Adjusts epoch timestamps to datetimes and removes variable preambles.
+    """Adjust epoch timestamps to datetimes and remove variable preambles.
 
     Parameters
     ----------
@@ -112,7 +114,7 @@ def preprocess(self, keep_original_names=False):
 
 
 def clean(self):
-    """Provides data cleaning based upon clean_level.
+    """Clean ICON FUV data to the specified level.
 
     Note
     ----
@@ -154,7 +156,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None, keep_original_names=False):
-    """Loads ICON FUV data using pysat into pandas.
+    """Load ICON FUV data using pysat into xarray.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -156,7 +156,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None, keep_original_names=False):
-    """Load ICON FUV data using pysat into xarray.
+    """Load ICON FUV data into xarray.Dataset object and pysat.Meta objects.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -217,7 +217,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None, keep_original_names=False):
-    """Load ICON IVM data using pysat into pandas.
+    """Load ICON IVM data into pandas.DataFrame and pysat.Meta objects.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -217,7 +217,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None, keep_original_names=False):
-    """Load ICON IVM data into pandas.DataFrame and pysat.Meta objects.
+    """Load ICON IVM data into `pandas.DataFrame` and `pysat.Meta` objects.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+"""Module for the ICON IVM instrument.
 
-"""Supports the Ion Velocity Meter (IVM)
-onboard the Ionospheric Connections (ICON) Explorer.
+Supports the Ion Velocity Meter (IVM) onboard the Ionospheric Connections
+(ICON) Explorer.
 
 Properties
 ----------
@@ -76,7 +77,7 @@ _password_req = {'b': {kk: True for kk in tags.keys()}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -96,7 +97,7 @@ def init(self):
 
 
 def preprocess(self, keep_original_names=False):
-    """Removes variable preambles.
+    """Remove variable preambles.
 
     Parameters
     ----------
@@ -112,7 +113,7 @@ def preprocess(self, keep_original_names=False):
 
 
 def clean(self):
-    """Provides data cleaning based upon clean_level.
+    """Clean ICON IVM data to the specified level.
 
     Note
     ----
@@ -216,7 +217,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None, keep_original_names=False):
-    """Loads ICON IVM data using pysat into pandas.
+    """Load ICON IVM data using pysat into pandas.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -275,7 +275,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None, keep_original_names=False):
-    """Load ICON FUV data into xarray.Dataset and pysat.Meta objects.
+    """Load ICON MIGHTI data into `xarray.Dataset` and `pysat.Meta` objects.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -275,7 +275,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None, keep_original_names=False):
-    """Load ICON FUV data using pysat into xarray.
+    """Load ICON FUV data into xarray.Dataset and pysat.Meta objects.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Michelson Interferometer for Global High-resolution
+"""Module for the ICON MIGHTI instrument.
+
+Supports the Michelson Interferometer for Global High-resolution
 Thermospheric Imaging (MIGHTI) instrument onboard the Ionospheric
 CONnection Explorer (ICON) satellite.  Accesses local data in
 netCDF format.
@@ -93,7 +95,7 @@ _test_dates = {jj: {kk: dt.datetime(2020, 1, 2) for kk in inst_ids[jj]}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -113,7 +115,7 @@ def init(self):
 
 
 def preprocess(self, keep_original_names=False):
-    """Adjusts epoch timestamps to datetimes and removes variable preambles.
+    """Adjust epoch timestamps to datetimes and remove variable preambles.
 
     Parameters
     ----------
@@ -130,7 +132,7 @@ def preprocess(self, keep_original_names=False):
 
 
 def clean(self):
-    """Provides data cleaning based upon clean_level.
+    """Clean ICON MIGHTI data to the specified level.
 
     Note
     ----
@@ -139,7 +141,7 @@ def clean(self):
     """
 
     def _clean_vars(var_list, flag, min_level):
-        """Cleans parameters in a list according to standard flags
+        """Clean parameters in a list according to standard flags.
 
         Parameters
         ----------
@@ -273,7 +275,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None, keep_original_names=False):
-    """Loads ICON FUV data using pysat into pandas.
+    """Load ICON FUV data using pysat into xarray.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/iss_fpmu.py
+++ b/pysatNASA/instruments/iss_fpmu.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Floating Potential Measurement Unit
+"""Module for the ISS FPMU instrument.
+
+Supports the Floating Potential Measurement Unit
 (FPMU) instrument onboard the International Space
 Station (ISS). Downloads data from the NASA
 Coordinated Data Analysis Web (CDAWeb).
@@ -49,7 +51,7 @@ _test_dates = {'': {'': dt.datetime(2017, 10, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -78,7 +80,7 @@ def init(self):
 
 
 def clean(self):
-    """Return FPMU data cleaned to the specified level.
+    """Clean ISS FPMU data to the specified level.
 
     Note
     ----

--- a/pysatNASA/instruments/methods/__init__.py
+++ b/pysatNASA/instruments/methods/__init__.py
@@ -1,3 +1,5 @@
+"""Methods for pysatNASA instruments."""
+
 from pysatNASA.instruments.methods._cdf import CDF  # noqa F401
 from pysatNASA.instruments.methods import cdaweb  # noqa F401
 from pysatNASA.instruments.methods import cnofs  # noqa F401

--- a/pysatNASA/instruments/methods/_cdf.py
+++ b/pysatNASA/instruments/methods/_cdf.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Provides CDF class to parse cdaweb CDF files.
-"""
+"""Provides CDF class to parse cdaweb CDF files."""
 
 import datetime as dt
 import numpy as np
@@ -13,7 +12,7 @@ from pysat import logger
 
 
 def convert_ndimensional(data, index=None, columns=None):
-    """Converts high-dimensional data to a Dataframe
+    """Convert high-dimensional data to a Dataframe.
 
     Parameters
     ----------
@@ -72,6 +71,8 @@ class CDF(object):
                  regnames=None,
                  datetime=True,
                  **kwargs):
+        """Initialize the CDF class."""
+
         self._raise_errors = raise_errors
         self._filename = filename
         self._varformat = varformat
@@ -96,15 +97,16 @@ class CDF(object):
         self.load_variables()
 
     def __enter__(self):
-        """Context manager protocol
-        enters runtime context related to this object.
+        """Enter runtime context related to this object.
+
         The with statement will bind this method’s return value
         to the target(s) specified in the as clause of the statement
         """
         return self
 
     def __exit__(self, type, value, tb):
-        """Context manager protocol
+        """Exit runtime context related to this object.
+
         If any exceptions occur while attempting to execute the block
         of code nested after the with statement, Python will pass
         information about the exception into this method
@@ -121,7 +123,7 @@ class CDF(object):
         pass
 
     def get_dependency(self, x_axis_var):
-        """Retrieves variable dependency unique to filename
+        """Retrieve variable dependency unique to filename.
 
         Parameter
         ---------
@@ -132,7 +134,7 @@ class CDF(object):
         return self._dependencies.get(self._filename + x_axis_var)
 
     def set_dependency(self, x_axis_var, x_axis_data):
-        """Sets variable dependency unique to filename
+        """Set variable dependency unique to filename.
 
         Parameters
         ----------
@@ -145,7 +147,7 @@ class CDF(object):
         self._dependencies[self._filename + x_axis_var] = x_axis_data
 
     def set_epoch(self, x_axis_var):
-        """Stores epoch dependency
+        """Store epoch dependency.
 
         Parameters
         ----------
@@ -234,7 +236,7 @@ class CDF(object):
                 self.set_dependency(x_axis_var, xdata)
 
     def get_index(self, variable_name):
-        """Return index of variable
+        """Retrieve index of variable.
 
         Parameters
         ----------
@@ -283,8 +285,8 @@ class CDF(object):
         return index_
 
     def load_variables(self):
-        """Loads cdf variables based on varformat
-        """
+        """Load cdf variables based on varformat."""
+
         varformat = self._varformat
         if varformat is None:
             varformat = ".*"
@@ -361,8 +363,7 @@ class CDF(object):
                          'min_val': ('ValidMin', float),
                          'max_val': ('ValidMax', float),
                          'fill_val': ('FillVal', float)}):
-        """
-        Exports loaded CDF data into data, meta for pysat module
+        """Export loaded CDF data into data, meta for pysat module.
 
         Parameters
         ----------

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Provides default routines for integrating NASA CDAWeb instruments into
-pysat. Adding new CDAWeb datasets should only require mininal user
-intervention.
+"""Provides default routines for NASA CDAWeb instruments into pysat.
+
+Note
+----
+Adding new CDAWeb datasets should only require mininal user intervention.
 
 """
 
@@ -113,7 +115,7 @@ def load(fnames, tag=None, inst_id=None, file_cadence=dt.timedelta(days=1),
 
 def download(date_array, tag=None, inst_id=None, supported_tags=None,
              remote_url='https://cdaweb.gsfc.nasa.gov', data_path=None):
-    """Routine to download NASA CDAWeb CDF data.
+    """Download NASA CDAWeb CDF data.
 
     This routine is intended to be used by pysat instrument modules supporting
     a particular NASA CDAWeb dataset.

--- a/pysatNASA/instruments/methods/cnofs.py
+++ b/pysatNASA/instruments/methods/cnofs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Provides non-instrument specific routines for DE2 data"""
+"""Provides non-instrument specific routines for C/NOFS data."""
 
 ackn_str = ' '.join(("The Communication Navigation Outage Forecast System",
                      "(C/NOFS) satellite data is provided through CDAWeb"))

--- a/pysatNASA/instruments/methods/de2.py
+++ b/pysatNASA/instruments/methods/de2.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Provides non-instrument specific routines for DE2 data"""
+"""Provides non-instrument specific routines for DE2 data."""
 
 ackn_str = "The Dynamics Explorer 2 satellite data is provided through CDAWeb"
 

--- a/pysatNASA/instruments/methods/gold.py
+++ b/pysatNASA/instruments/methods/gold.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Provides non-instrument specific routines for GOLD data"""
+"""Provides non-instrument specific routines for GOLD data."""
 
 ack_str = ' '.join(('This is a data product from the NASA Global-scale',
                     'Observations of the Limb and Disk (GOLD) mission, an',

--- a/pysatNASA/instruments/methods/icon.py
+++ b/pysatNASA/instruments/methods/icon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Provides non-instrument specific routines for ICON data"""
+"""Provides non-instrument specific routines for ICON data."""
 
 from pysat.instruments.methods import general as mm_gen
 
@@ -101,7 +101,7 @@ refs = {'euv': ' '.join(('Stephan, A.W., Meier, R.R., England, S.L. et al.',
 
 
 def remove_preamble(inst):
-    """Removes preambles in variable names
+    """Remove preambles in variable names.
 
     Parameters
     -----------

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports OMNI Combined, Definitive, IMF and Plasma Data, and Energetic
+"""Module for the OMNI HRO instrument.
+
+Supports OMNI Combined, Definitive, IMF and Plasma Data, and Energetic
 Proton Fluxes, Time-Shifted to the Nose of the Earth's Bow Shock, plus Solar
 and Magnetic Indices. Downloads data from the NASA Coordinated Data Analysis
 Web (CDAWeb). Supports both 5 and 1 minute files.
@@ -80,7 +82,7 @@ _test_dates = {'': {'1min': dt.datetime(2009, 1, 1),
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -100,7 +102,7 @@ def init(self):
 
 
 def clean(self):
-    """ Cleaning function for OMNI data
+    """Clean OMNI HRO data to the specified level.
 
     Note
     ----
@@ -164,8 +166,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def time_shift_to_magnetic_poles(inst):
-    """ OMNI data is time-shifted to bow shock. Time shifted again
-    to intersections with magnetic pole.
+    """Shift OMNI times to intersection with the magnetic pole.
 
     Parameters
     ----------
@@ -174,8 +175,10 @@ def time_shift_to_magnetic_poles(inst):
 
     Note
     ----
-    Time shift calculated using distance to bow shock nose (BSN)
-    and velocity of solar wind along x-direction.
+    - Time shift calculated using distance to bow shock nose (BSN)
+      and velocity of solar wind along x-direction.
+    - OMNI data is time-shifted to bow shock. Time shifted again
+      to intersections with magnetic pole.
 
     Warnings
     --------
@@ -212,7 +215,7 @@ def time_shift_to_magnetic_poles(inst):
 
 
 def calculate_clock_angle(inst):
-    """ Calculate IMF clock angle and magnitude of IMF in GSM Y-Z plane
+    """Calculate IMF clock angle and magnitude of IMF in GSM Y-Z plane.
 
     Parameters
     -----------
@@ -237,8 +240,7 @@ def calculate_clock_angle(inst):
 def calculate_imf_steadiness(inst, steady_window=15, min_window_frac=0.75,
                              max_clock_angle_std=(90.0 / np.pi),
                              max_bmag_cv=0.5):
-    """ Calculate IMF steadiness using clock angle standard deviation and
-    the coefficient of variation of the IMF magnitude in the GSM Y-Z plane
+    """Calculate IMF steadiness and add parameters to instrument data.
 
     Parameters
     ----------
@@ -254,6 +256,11 @@ def calculate_imf_steadiness(inst, steady_window=15, min_window_frac=0.75,
     max_bmag_cv : float
         Maximum coefficient of variation of the IMF magnitude in the GSM
         Y-Z plane (default=0.5)
+
+    Note
+    ----
+    Uses clock angle standard deviation and the coefficient of variation of
+    the IMF magnitude in the GSM Y-Z plane
 
     """
 
@@ -323,7 +330,7 @@ def calculate_imf_steadiness(inst, steady_window=15, min_window_frac=0.75,
 
 
 def calculate_dayside_reconnection(inst):
-    """ Calculate the dayside reconnection rate (Milan et al. 2014)
+    """Calculate the dayside reconnection rate (Milan et al. 2014).
 
     Parameters
     ----------

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -1,4 +1,6 @@
-"""Supports the Nmax data product from the Global Observations of the Limb and
+"""Module for the SES14 GOLD instrument.
+
+Supports the Nmax data product from the Global Observations of the Limb and
 Disk (GOLD) satellite.  Accesses data in netCDF format.
 
 Properties
@@ -65,7 +67,7 @@ _test_dates = {'': {'nmax': dt.datetime(2020, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -89,7 +91,7 @@ def init(self):
 
 
 def clean(self):
-    """Provides data cleaning based upon clean_level.
+    """Clean SES14 GOLD data to the specified level.
 
     Routine is called by pysat, and not by the end user directly.
 
@@ -136,7 +138,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None):
-    """Loads GOLD NMAX data using pysat into xarray
+    """Load GOLD NMAX data using pysat into xarray.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -138,7 +138,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None):
-    """Load GOLD NMAX data into xarray.Dataset and pysat.Meta objects.
+    """Load GOLD NMAX data into `xarray.Dataset` and `pysat.Meta` objects.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -138,7 +138,7 @@ list_remote_files = functools.partial(cdw.list_remote_files,
 
 
 def load(fnames, tag=None, inst_id=None):
-    """Load GOLD NMAX data using pysat into xarray.
+    """Load GOLD NMAX data into xarray.Dataset and pysat.Meta objects.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Supports the Sounding of the Atmosphere using Broadband Emission Radiometry
+"""The TIMED SABER instrument.
+
+Supports the Sounding of the Atmosphere using Broadband Emission Radiometry
 (SABER) instrument on the Thermosphere Ionosphere Mesosphere Energetics
 Dynamics (TIMED) satellite.
 
@@ -81,7 +83,7 @@ _test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -98,7 +100,7 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return TIMED SABER data cleaned to the specified level
+    """Clean TIMED SABER data to the specified level.
 
     Note
     ----

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -65,7 +65,7 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -88,7 +88,7 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return TIMED SEE data cleaned to the specified level
+    """Clean TIMED SEE data to the specified level.
 
     Note
     ----

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,7 @@
 coveralls
 flake8
+flake8-docstrings
+hacking
 pytest
 pytest-cov
 pytest-ordering


### PR DESCRIPTION
# Description

Updates docstring style and import order in preparation for flake8-docstrings and hacking tests.

Adds `flake8-docstrings` and `hacking` to CI test environment.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local run of flake8.

## Test Configuration
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.2
* `flake8-docstrings` and `hacking`

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes 
- [na] Update zenodo.json file for new code contributors
