### PR TITLE
ENH: use `multi_file_day` = True for ICON IVM data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.0.4] - 2021-XX-XX
 * Include flake8 linting of docstrings and style in Github Actions
+* Fixed a bug in loading ICON IVM data (added multi_file_day = True)
 
 ## [0.0.3] - 2021-06-17
 * Include Windows tests in Github Actions

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -62,7 +62,7 @@ tags = {'': 'Level 2 public geophysical data'}
 # is not available as of Jun 26 2020, as this mode has not yet been engaged.
 # Bypassing tests and warning checks via the password_req flag
 inst_ids = {'a': [''], 'b': ['']}
-
+multi_file_day = True
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes


### PR DESCRIPTION
# Description

Addresses #87

ICON IVM data files are slightly misaligned with UT, including about 30s of the previous day and dropping the last 30s.  The `multi_file_day` option corrects for this and allows one complete day to be loaded when requested.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Assuming registration and download,
```
import pysat
ivm = pysat.Instrument('icon', 'ivm', inst_id='a')
ivm.load(2020, 1)
```
Inspection of data should align with day boundaries.

## Test Configuration
* Operating system: Mac OS X 10.15.7
* Version number: python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [na] Update zenodo.json file for new code contributors
