### PR TITLE
STY: clean up imports in package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.0.4] - 2021-XX-XX
 * Include flake8 linting of docstrings and style in Github Actions
+* Maintenance
+  * Removed dummy vars after importing instruments and constellations
 
 ## [0.0.3] - 2021-06-17
 * Include Windows tests in Github Actions

--- a/pysatNASA/constellations/__init__.py
+++ b/pysatNASA/constellations/__init__.py
@@ -9,3 +9,6 @@ __all__ = ['de2', 'icon']
 
 for const in __all__:
     exec("from pysatNASA.constellations import {:}".format(const))
+
+# Remove dummy variable
+del const

--- a/pysatNASA/instruments/__init__.py
+++ b/pysatNASA/instruments/__init__.py
@@ -14,3 +14,6 @@ __all__ = ['cnofs_ivm', 'cnofs_plp', 'cnofs_vefi',
 
 for inst in __all__:
     exec("from pysatNASA.instruments import {x}".format(x=inst))
+
+# Remove dummy variable
+del inst


### PR DESCRIPTION
# Description

Currently dummy variables are used as part of the import process for instruments and constellations.  This removes those so a random string is not attached to the package

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To inspect modules and attrs attached, use tab:
```
import pysaNASA
pysatNASA.instruments.[tab]
```
Should only be a list of modules.

## Test Configuration
* Operating system: Mac OS X 10.15.7
* Version number: python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [na] Update zenodo.json file for new code contributors
