### PR TITLE
TST: add _test_load_opt to icon instruments

### DIFF
--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -67,6 +67,7 @@ pandas_format = False
 # Instrument test attributes
 
 _test_dates = {'': {'': dt.datetime(2020, 1, 1)}}
+_test_load_opt = {'': {'': {'keep_original_names': True}}}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -71,6 +71,7 @@ pandas_format = False
 # Instrument test attributes
 
 _test_dates = {'': {kk: dt.datetime(2020, 1, 1) for kk in tags.keys()}}
+_test_load_opt = {'': {kk: {'keep_original_names': True} for kk in tags.keys()}}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -71,6 +71,8 @@ _test_dates = {'a': {'': dt.datetime(2020, 1, 1)},
                'b': {'': dt.datetime(2020, 1, 1)}}  # IVM-B not yet engaged
 _test_download = {'b': {kk: False for kk in tags.keys()}}
 _password_req = {'b': {kk: True for kk in tags.keys()}}
+_test_load_opt = {jj: {'': {'keep_original_names': True}}
+                  for jj in inst_ids.keys()}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -89,6 +89,8 @@ pandas_format = False
 
 _test_dates = {jj: {kk: dt.datetime(2020, 1, 2) for kk in inst_ids[jj]}
                for jj in inst_ids.keys()}
+_test_load_opt = {jj: {kk: {'keep_original_names': True} for kk in inst_ids[jj]}
+                  for jj in inst_ids.keys()}
 
 # ----------------------------------------------------------------------------
 # Instrument methods


### PR DESCRIPTION
Adds options to load ICON data without removing the variable prefixes in unit tests.  