### PR TITLE
Omni quickfix meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.0.4] - 2021-XX-XX
 * Include flake8 linting of docstrings and style in Github Actions
 * Fixed a bug in loading ICON IVM data (added multi_file_day = True)
+* Fixed a bug where OMNI meta data float values are loaded as arrays
 * Maintenance
   * Removed dummy vars after importing instruments and constellations
 

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -114,7 +114,7 @@ def clean(self):
     """
     for key in self.data.columns:
         if key != 'Epoch':
-            fill = self.meta[key, self.meta.labels.fill_val][0]
+            fill = self.meta[key, self.meta.labels.fill_val]
             idx, = np.where(self[key] == fill)
             # Set the fill values to NaN
             self[idx, key] = np.nan
@@ -146,9 +146,6 @@ list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags,
                                file_cadence=pds.DateOffset(months=1))
 
-# Set the load routine
-load = functools.partial(cdw.load, file_cadence=pds.DateOffset(months=1))
-
 # Set the download routine
 remote_dir = '/pub/data/omni/omni_cdaweb/hro_{tag:s}/{{year:4d}}/'
 download_tags = {inst_id: {tag: {'remote_dir': remote_dir.format(tag=tag),
@@ -160,6 +157,50 @@ download = functools.partial(cdw.download, supported_tags=download_tags)
 # Set the list_remote_files routine
 list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=download_tags)
+
+
+# Set the load routine
+def load(fnames, tag=None, inst_id=None, file_cadence=pds.DateOffset(months=1),
+         flatten_twod=True):
+    """Load data and fix meta data.
+
+    Parameters
+    ----------
+    fnames : pandas.Series
+        Series of filenames
+    tag : str or NoneType
+        tag or None (default=None)
+    inst_id : str or NoneType
+        satellite id or None (default=None)
+    file_cadence : dt.timedelta or pds.DateOffset
+        pysat assumes a daily file cadence, but some instrument data files
+        contain longer periods of time.  This parameter allows the specification
+        of regular file cadences greater than or equal to a day (e.g., weekly,
+        monthly, or yearly). (default=dt.timedelta(days=1))
+    flatted_twod : bool
+        Flattens 2D data into different columns of root DataFrame rather
+        than produce a Series of DataFrames. (default=True)
+
+    Returns
+    -------
+    data : pandas.DataFrame
+        Object containing satellite data
+    meta : pysat.Meta
+        Object containing metadata such as column names and units
+
+    """
+
+    data, meta = cdw.load(fnames, tag=tag, inst_id=inst_id,
+                          file_cadence=file_cadence, flatten_twod=flatten_twod)
+
+    # Update the metadata, as float values may be stored as arrays
+    for dval in meta.keys():
+        for label in meta[dval].keys():
+            if hasattr(meta[dval][label], 'shape'):
+                meta[dval] = {label: meta[dval][label][0]}
+
+    return data, meta
+
 
 # ----------------------------------------------------------------------------
 # Local functions

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-coveralls
+coveralls<3.3
 flake8
 flake8-docstrings
 hacking


### PR DESCRIPTION
# Description

Inelegantly addresses #95 by altering the meta data in the load routine.


## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
omni = pysat.Instrument('omni', 'hro', '1min')
omni.load(2020, 102)
omni.meta['SYM_D']
```

Produces:

```
FIELDNAM                                              SYM/D index
SCALEMIN                                                    -1000
SCALEMAX                                                     1000
VAR_TYPE                                                     data
FORMAT                                                         I5
DEPEND_0                                                    Epoch
LABLAXIS                                              SYM/D index
DISPLAY_TYPE                                          time_series
units                                                          nT
long_name                                                   SYM_D
notes                                                         NaN
desc            SYM/D - 1-minute SYM/D index,from WDC Kyoto (1...
value_min                                                   -1000
value_max                                                    1000
fill                                                        99999
children                                                     None
Name: SYM_D, dtype: object
```

## Test Configuration
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant: develop branch of pysat

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
