### PR TITLE
BUG: limit coveralls version

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-coveralls
+coveralls<3.3
 flake8
 flake8-docstrings
 hacking


### PR DESCRIPTION
# Description

Coveralls 3.3 is failing on github actions across platforms.  Limiting install to see if something in the new version is at fault.

https://github.com/TheKevJames/coveralls-python/releases

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

If this successfully runs on Github Actions, it works.

## Test Configuration
Github Actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
