### PR TITLE
MAINT: update for NEP29, pip 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9", "3.10"]
         numpy_ver: [latest]
         include:
-          - python-version: "3.7"
-            numpy_ver: "1.18"
+          - python-version: "3.8"
+            numpy_ver: "1.19"
             os: ubuntu-latest
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
 
     - name: Install standard dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r test_requirements.txt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Fixed a bug where OMNI meta data float values are loaded as arrays
 * Maintenance
   * Removed dummy vars after importing instruments and constellations
+  * Updated NEP29 compliance in Github Actions
+  * Limit versions of hacking for improved pip compliance
 
 ## [0.0.3] - 2021-06-17
 * Include Windows tests in Github Actions

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 coveralls<3.3
 flake8
 flake8-docstrings
-hacking
+hacking>=1.0
 pytest
 pytest-cov
 pytest-ordering


### PR DESCRIPTION
# Description

Updates compliance for NEP29 (dropping tests for python 3.7, numpy 1.18) and pip 22 (limits versions of `hacking` to check).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Update to Github Actions environment.  Tested there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
