### PR TITLE
MAINT: update cdflib standards for 0.4+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated NEP29 compliance in Github Actions
   * Limit versions of hacking for improved pip compliance
   * Update instrument template standards
+  * Removed cap on cdflib
 
 
 ## [0.0.2] - 2021-06-07

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,8 +19,8 @@ Python 3.7+ and pysat 3.0.0+.
  ================ =================
  Common modules   Community modules
  ================ =================
-  beautifulsoup4   cdflib
-  lxml             pysat
+  beautifulsoup4   cdflib>=0.4.4
+  lxml             pysat>=3.0.0
   netCDF4
   numpy
   pandas

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -108,7 +108,7 @@ def clean(self):
 
     for key in self.data.columns:
         if key != 'Epoch':
-            fill = self.meta[key, self.meta.labels.fill_val][0]
+            fill = self.meta[key, self.meta.labels.fill_val]
             idx, = np.where(self[key] == fill)
             self[idx, key] = np.nan
     return

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -193,12 +193,6 @@ def load(fnames, tag=None, inst_id=None, file_cadence=pds.DateOffset(months=1),
     data, meta = cdw.load(fnames, tag=tag, inst_id=inst_id,
                           file_cadence=file_cadence, flatten_twod=flatten_twod)
 
-    # Update the metadata, as float values may be stored as arrays
-    for dval in meta.keys():
-        for label in meta[dval].keys():
-            if hasattr(meta[dval][label], 'shape'):
-                meta[dval] = {label: meta[dval][label][0]}
-
     return data, meta
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ netCDF4
 requests
 beautifulsoup4
 lxml
-cdflib>0.3.20
+cdflib>=0.4.4
 numpy
 pandas
 pysat>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ netCDF4
 requests
 beautifulsoup4
 lxml
-cdflib<0.3.20
+cdflib>0.3.20
 numpy
 pandas
 pysat>=3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,11 +37,11 @@ install_requires =
   requests
   beautifulsoup4
   lxml
-  cdflib>0.3.20
+  cdflib
   numpy
   pandas
   xarray
-  pysat>=3.0.0
+  pysat
 
 [coverage:report]
 omit =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
   requests
   beautifulsoup4
   lxml
-  cdflib<0.3.20
+  cdflib>0.3.20
   numpy
   pandas
   xarray


### PR DESCRIPTION
# Description

Addresses #111

The version cap for cdflib was employed to avoid bugs and incompatibilities in that version, which have been since fixed.  This accepts only newer versions.

The new version of cdflib avoids the issue with metadata stored in arrays.  The workarounds for meta have been removed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
plp = pysat.Instrument('cnofs', 'plp')
plp.load(2009, 1)
```
Data should successfully load.

## Test Configuration
* Operating system: Mac OS X 11.6.5
* Version number: Python 3.8.11
* cdflib 0.4.4

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
