### PR TITLE
STY: reduce duplication for init and clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.0.4] - 2022-XX-XX
+* Maintenance
+  * Reduce duplication of code in instrument modules
+
 ## [0.0.3] - 2022-05-18
 * Include flake8 linting of docstrings and style in Github Actions
 * Include Windows tests in Github Actions

--- a/pysatNASA/constellations/__init__.py
+++ b/pysatNASA/constellations/__init__.py
@@ -4,11 +4,22 @@ Each instrument is contained within a subpackage of the pysatNASA.instruments
 package.
 """
 
+import logging
+
+import pysat
 
 __all__ = ['de2', 'icon']
 
+# Save current level and turn off before constellation import
+user_level = pysat.logger.level
+pysat.logger.setLevel(logging.WARNING)
+
+# Import contellation objects
 for const in __all__:
     exec("from pysatNASA.constellations import {:}".format(const))
 
+# Restore user level
+pysat.logger.setLevel(user_level)
+
 # Remove dummy variable
-del const
+del const, user_level

--- a/pysatNASA/constellations/__init__.py
+++ b/pysatNASA/constellations/__init__.py
@@ -15,7 +15,7 @@ __all__ = ['de2', 'icon']
 user_level = pysat.logger.level
 pysat.logger.setLevel(logging.WARNING)
 
-# Import contellation objects
+# Import constellation objects
 for const in __all__:
     exec("from pysatNASA.constellations import {:}".format(const))
 

--- a/pysatNASA/constellations/__init__.py
+++ b/pysatNASA/constellations/__init__.py
@@ -10,6 +10,7 @@ import pysat
 
 __all__ = ['de2', 'icon']
 
+# TODO(#89): reevaluate logger suppression if fixes implemented in pysat
 # Save current level and turn off before constellation import
 user_level = pysat.logger.level
 pysat.logger.setLevel(logging.WARNING)

--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -60,10 +60,10 @@ import functools
 import numpy as np
 
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import cnofs as mm_cnofs
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -82,18 +82,8 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 # Instrument methods
 
 
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    """
-    logger.info(mm_cnofs.ackn_str)
-    self.acknowledgements = mm_cnofs.ackn_str
-    self.references = '\n'.join((mm_cnofs.refs['mission'],
-                                 mm_cnofs.refs['ivm']))
-
-    return
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_cnofs, name=name)
 
 
 def preprocess(self):

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -61,10 +61,10 @@ import functools
 import numpy as np
 
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import cnofs as mm_cnofs
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -82,19 +82,8 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 # ----------------------------------------------------------------------------
 # Instrument methods
 
-
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    """
-    logger.info(mm_cnofs.ackn_str)
-    self.acknowledgements = mm_cnofs.ackn_str
-    self.references = '\n'.join((mm_cnofs.refs['mission'],
-                                 mm_cnofs.refs['plp']))
-
-    return
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_cnofs, name=name)
 
 
 def clean(self):

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -63,10 +63,10 @@ import functools
 import numpy as np
 
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import cnofs as mm_cnofs
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -85,18 +85,8 @@ _test_dates = {'': {'dc_b': dt.datetime(2009, 1, 1)}}
 # Instrument methods
 
 
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    """
-    logger.info(mm_cnofs.ackn_str)
-    self.acknowledgements = mm_cnofs.ackn_str
-    self.references = '\n'.join((mm_cnofs.refs['mission'],
-                                 mm_cnofs.refs['vefi']))
-
-    return
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_cnofs, name=name)
 
 
 def clean(self):

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -52,7 +52,6 @@ Warnings
 
 import datetime as dt
 import functools
-import warnings
 
 from pysat.instruments.methods import general as mm_gen
 
@@ -79,23 +78,8 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
 # Use standard init routine
 init = functools.partial(mm_nasa.init, module=mm_de2, name=name)
-
-
-def clean(self):
-    """Clean DE2 LANG data to the specified level.
-
-    Note
-    ----
-    'clean' - Not specified
-    'dusty' - Not specified
-    'dirty' - Not specified
-    'none'  No cleaning applied, routine not called in this case.
-
-    """
-    warnings.warn('No cleaning routines available for DE2 LANG')
-
-    return
-
+# No cleaning, use standard warning function instead
+clean = mm_nasa.clean_warn
 
 # ----------------------------------------------------------------------------
 # Instrument functions

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -55,10 +55,10 @@ import functools
 import warnings
 
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import de2 as mm_de2
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -77,17 +77,8 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 # Instrument methods
 
 
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    """
-
-    logger.info(mm_de2.ackn_str)
-    self.acknowledgements = mm_de2.ackn_str
-    self.references = mm_de2.refs['lang']
-    return
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_de2, name=name)
 
 
 def clean(self):

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -78,6 +78,7 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 
 # Use standard init routine
 init = functools.partial(mm_nasa.init, module=mm_de2, name=name)
+
 # No cleaning, use standard warning function instead
 clean = mm_nasa.clean_warn
 

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -78,10 +78,10 @@ import functools
 import warnings
 
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import de2 as mm_de2
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -100,17 +100,8 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 # Instrument methods
 
 
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    """
-
-    logger.info(mm_de2.ackn_str)
-    self.acknowledgements = mm_de2.ackn_str
-    self.references = mm_de2.refs['lang']
-    return
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_de2, name=name)
 
 
 def clean(self):

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -75,7 +75,6 @@ Warnings
 
 import datetime as dt
 import functools
-import warnings
 
 from pysat.instruments.methods import general as mm_gen
 
@@ -103,22 +102,8 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 # Use standard init routine
 init = functools.partial(mm_nasa.init, module=mm_de2, name=name)
 
-
-def clean(self):
-    """Clean DE2 NACS data to the specified level.
-
-    Note
-    ----
-    'clean' - Not specified
-    'dusty' - Not specified
-    'dirty' - Not specified
-    'none'  No cleaning applied, routine not called in this case.
-
-    """
-    warnings.warn('No cleaning routines available for DE2 NACS')
-
-    return
-
+# No cleaning, use standard warning function instead
+clean = mm_nasa.clean_warn
 
 # ----------------------------------------------------------------------------
 # Instrument functions

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -64,10 +64,10 @@ import functools
 import warnings
 
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import de2 as mm_de2
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -86,17 +86,8 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 # Instrument methods
 
 
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    """
-
-    logger.info(mm_de2.ackn_str)
-    self.acknowledgements = mm_de2.ackn_str
-    self.references = mm_de2.refs['lang']
-    return
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_de2, name=name)
 
 
 def clean(self):

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -61,7 +61,6 @@ Warnings
 
 import datetime as dt
 import functools
-import warnings
 
 from pysat.instruments.methods import general as mm_gen
 
@@ -89,22 +88,8 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 # Use standard init routine
 init = functools.partial(mm_nasa.init, module=mm_de2, name=name)
 
-
-def clean(self):
-    """Clean DE2 RPA data to the specified level.
-
-    Note
-    ----
-    'clean' - Not specified
-    'dusty' - Not specified
-    'dirty' - Not specified
-    'none'  No cleaning applied, routine not called in this case.
-
-    """
-    warnings.warn('No cleaning routines available for DE2 RPA')
-
-    return
-
+# No cleaning, use standard warning function instead
+clean = mm_nasa.clean_warn
 
 # ----------------------------------------------------------------------------
 # Instrument functions

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -72,7 +72,6 @@ Warnings
 
 import datetime as dt
 import functools
-import warnings
 
 from pysat.instruments.methods import general as mm_gen
 
@@ -100,22 +99,8 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 # Use standard init routine
 init = functools.partial(mm_nasa.init, module=mm_de2, name=name)
 
-
-def clean(self):
-    """Clean DE2 LANG data to the specified level.
-
-    Note
-    ----
-    'clean' - Not specified
-    'dusty' - Not specified
-    'dirty' - Not specified
-    'none'  No cleaning applied, routine not called in this case.
-
-    """
-    warnings.warn('No cleaning routines available for DE2 WATS')
-
-    return
-
+# No cleaning, use standard warning function instead
+clean = mm_nasa.clean_warn
 
 # ----------------------------------------------------------------------------
 # Instrument functions

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -75,10 +75,10 @@ import functools
 import warnings
 
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import de2 as mm_de2
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -97,17 +97,8 @@ _test_dates = {'': {'': dt.datetime(1983, 1, 1)}}
 # Instrument methods
 
 
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    """
-
-    logger.info(mm_de2.ackn_str)
-    self.acknowledgements = mm_de2.ackn_str
-    self.references = mm_de2.refs['lang']
-    return
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_de2, name=name)
 
 
 def clean(self):

--- a/pysatNASA/instruments/formosat1_ivm.py
+++ b/pysatNASA/instruments/formosat1_ivm.py
@@ -24,12 +24,12 @@ Warnings
 
 import datetime as dt
 import functools
-import warnings
 
 from pysat.instruments.methods import general as mm_gen
 from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -74,19 +74,8 @@ def init(self):
     return
 
 
-def clean(self):
-    """Clean FORMOSAT-1 IVM data to the specified level.
-
-    Note
-    ----
-    No cleaning currently available for FORMOSAT-1 IVM.
-
-    """
-
-    warnings.warn("No cleaning currently available for FORMOSAT-1")
-
-    return
-
+# No cleaning, use standard warning function instead
+clean = mm_nasa.clean_warn
 
 # ----------------------------------------------------------------------------
 # Instrument functions

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -43,10 +43,10 @@ import functools
 
 import pysat
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import icon as mm_icon
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -67,24 +67,8 @@ _test_dates = {'': {'': dt.datetime(2020, 1, 1)}}
 # Instrument methods
 
 
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    Parameters
-    -----------
-    inst : pysat.Instrument
-        Instrument class object
-
-    """
-
-    logger.info(mm_icon.ackn_str)
-    self.acknowledgements = mm_icon.ackn_str
-    self.references = ''.join((mm_icon.refs['mission'],
-                               mm_icon.refs['euv']))
-
-    return
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_icon, name=name)
 
 
 def preprocess(self, keep_original_names=False):

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -45,8 +45,8 @@ import pysat
 from pysat.instruments.methods import general as mm_gen
 
 from pysatNASA.instruments.methods import cdaweb as cdw
-from pysatNASA.instruments.methods import icon as mm_icon
 from pysatNASA.instruments.methods import general as mm_nasa
+from pysatNASA.instruments.methods import icon as mm_icon
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -46,8 +46,8 @@ from pysat.instruments.methods import general as mm_gen
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import icon as mm_icon
+from pysatNASA.instruments.methods import general as mm_nasa
 
-logger = pysat.logger
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -69,24 +69,8 @@ _test_dates = {'': {kk: dt.datetime(2020, 1, 1) for kk in tags.keys()}}
 # Instrument methods
 
 
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    Parameters
-    -----------
-    inst : pysat.Instrument
-        Instrument class object
-
-    """
-
-    logger.info(mm_icon.ackn_str)
-    self.acknowledgements = mm_icon.ackn_str
-    self.references = ''.join((mm_icon.refs['mission'],
-                               mm_icon.refs['fuv']))
-
-    return
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_icon, name=name)
 
 
 def preprocess(self, keep_original_names=False):

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -45,8 +45,8 @@ import pysat
 from pysat.instruments.methods import general as mm_gen
 
 from pysatNASA.instruments.methods import cdaweb as cdw
-from pysatNASA.instruments.methods import icon as mm_icon
 from pysatNASA.instruments.methods import general as mm_nasa
+from pysatNASA.instruments.methods import icon as mm_icon
 
 
 # ----------------------------------------------------------------------------

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -45,8 +45,8 @@ import pysat
 from pysat.instruments.methods import general as mm_gen
 
 from pysatNASA.instruments.methods import cdaweb as cdw
-from pysatNASA.instruments.methods import icon as mm_icon
 from pysatNASA.instruments.methods import general as mm_nasa
+from pysatNASA.instruments.methods import icon as mm_icon
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -43,10 +43,10 @@ import numpy as np
 
 import pysat
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import icon as mm_icon
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -76,24 +76,8 @@ _password_req = {'b': {kk: True for kk in tags.keys()}}
 # Instrument methods
 
 
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    Parameters
-    -----------
-    inst : pysat.Instrument
-        Instrument class object
-
-    """
-
-    logger.info(mm_icon.ackn_str)
-    self.acknowledgements = mm_icon.ackn_str
-    self.references = ''.join((mm_icon.refs['mission'],
-                               mm_icon.refs['ivm']))
-
-    return
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_icon, name=name)
 
 
 def preprocess(self, keep_original_names=False):

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -58,8 +58,8 @@ import pysat
 from pysat.instruments.methods import general as mm_gen
 
 from pysatNASA.instruments.methods import cdaweb as cdw
-from pysatNASA.instruments.methods import icon as mm_icon
 from pysatNASA.instruments.methods import general as mm_nasa
+from pysatNASA.instruments.methods import icon as mm_icon
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -56,10 +56,10 @@ import functools
 
 import pysat
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import icon as mm_icon
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -87,24 +87,8 @@ _test_dates = {jj: {kk: dt.datetime(2020, 1, 2) for kk in inst_ids[jj]}
 # Instrument methods
 
 
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    Parameters
-    -----------
-    inst : pysat.Instrument
-        Instrument class object
-
-    """
-
-    logger.info(mm_icon.ackn_str)
-    self.acknowledgements = mm_icon.ackn_str
-    self.references = ''.join((mm_icon.refs['mission'],
-                               mm_icon.refs['mighti']))
-
-    return
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_icon, name=name)
 
 
 def preprocess(self, keep_original_names=False):

--- a/pysatNASA/instruments/methods/__init__.py
+++ b/pysatNASA/instruments/methods/__init__.py
@@ -4,4 +4,5 @@ from pysatNASA.instruments.methods._cdf import CDF  # noqa F401
 from pysatNASA.instruments.methods import cdaweb  # noqa F401
 from pysatNASA.instruments.methods import cnofs  # noqa F401
 from pysatNASA.instruments.methods import de2  # noqa F401
+from pysatNASA.instruments.methods import general  # noqa F401
 from pysatNASA.instruments.methods import icon  # noqa F401

--- a/pysatNASA/instruments/methods/general.py
+++ b/pysatNASA/instruments/methods/general.py
@@ -1,0 +1,33 @@
+"""General methods for NASA instruments."""
+
+import warnings
+
+import pysat
+
+
+def init(self, module, name):
+    """Initialize the Instrument object with instrument specific values.
+
+    Parameters
+    -----------
+    module : python module
+        module from general methods, eg, icon, de2, cnofs, etc
+    name : str
+        name of instrument of interest, eg, 'ivm'
+
+    Runs once upon instantiation.
+
+    """
+
+    # Set acknowledgements
+    self.acknowledgements = getattr(module, 'ackn_str')
+    pysat.logger.info(self.acknowledgements)
+
+    # Set references
+    refs = getattr(module, 'refs')
+    if 'mission' in refs.keys():
+        self.references = '\n'.join((refs['mission'], refs[name]))
+    else:
+        self.references = refs[name]
+
+    return

--- a/pysatNASA/instruments/methods/general.py
+++ b/pysatNASA/instruments/methods/general.py
@@ -10,11 +10,13 @@ def init(self, module, name):
 
     Parameters
     -----------
-    module : python module
+    module : module
         module from general methods, eg, icon, de2, cnofs, etc
     name : str
         name of instrument of interest, eg, 'ivm'
 
+    Note
+    ----
     Runs once upon instantiation.
 
     """
@@ -34,7 +36,7 @@ def init(self, module, name):
 
 
 def clean_warn(self):
-    """Warn user that cleaning not yet available for this dataset.
+    """Warn user that cleaning not yet available for this data set.
 
     Note
     ----

--- a/pysatNASA/instruments/methods/general.py
+++ b/pysatNASA/instruments/methods/general.py
@@ -31,3 +31,20 @@ def init(self, module, name):
         self.references = refs[name]
 
     return
+
+
+def clean_warn(self):
+    """Warn user that cleaning not yet available for this dataset.
+
+    Note
+    ----
+    'clean' - Not specified
+    'dusty' - Not specified
+    'dirty' - Not specified
+    'none'  No cleaning applied, routine not called in this case.
+
+    """
+    warnings.warn(' '.join(('No cleaning routines available for',
+                            self.platform, self.name)))
+
+    return

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -33,7 +33,6 @@ Examples
 
 import datetime as dt
 import functools
-import warnings
 
 from pysat.instruments.methods import general as ps_gen
 from pysat import logger
@@ -41,6 +40,7 @@ from pysat.utils import load_netcdf4
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import gold as mm_gold
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -85,25 +85,8 @@ def init(self):
     return
 
 
-def clean(self):
-    """Clean SES14 GOLD data to the specified level.
-
-    Routine is called by pysat, and not by the end user directly.
-
-    Parameters
-    -----------
-    self : pysat.Instrument
-        Instrument class object, whose attribute clean_level is used to return
-        the desired level of data selectivity.
-
-    Note
-    ----
-        Supports 'clean', 'dusty', 'dirty', 'none'
-
-    """
-
-    warnings.warn("Cleaning actions for GOLD Nmax are not yet implemented.")
-    return
+# No cleaning, use standard warning function instead
+clean = mm_nasa.clean_warn
 
 
 # ----------------------------------------------------------------------------

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -39,8 +39,8 @@ from pysat import logger
 from pysat.utils import load_netcdf4
 
 from pysatNASA.instruments.methods import cdaweb as cdw
-from pysatNASA.instruments.methods import gold as mm_gold
 from pysatNASA.instruments.methods import general as mm_nasa
+from pysatNASA.instruments.methods import gold as mm_gold
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -45,13 +45,13 @@ Warnings
 
 import datetime as dt
 import functools
-import warnings
 
 # CDAWeb methods prewritten for pysat
 from pysat.instruments.methods import general as mm_gen
 from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -94,23 +94,8 @@ def init(self):
     return
 
 
-def clean(self):
-    """Clean TIMED SABER data to the specified level.
-
-    Note
-    ----
-    'clean' All parameters should be good, suitable for statistical and
-            case studies
-    'dusty' All paramers should generally be good though same may
-            not be great
-    'dirty' There are data areas that have issues, data should be used
-            with caution
-    'none'  No cleaning applied, routine not called in this case.
-
-    """
-    warnings.warn('no cleaning routine available for TIMED SABER')
-
-    return
+# No cleaning, use standard warning function instead
+clean = mm_nasa.clean_warn
 
 
 # ----------------------------------------------------------------------------

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -40,12 +40,12 @@ Warnings
 import datetime as dt
 import functools
 import pandas as pds
-import warnings
 
 from pysat.instruments.methods import general as mm_gen
 from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -87,17 +87,8 @@ def init(self):
     return
 
 
-def clean(self):
-    """Clean TIMED SEE data to the specified level.
-
-    Note
-    ----
-    No cleaning currently available.
-
-    """
-    warnings.warn('no cleaning routines available for TIMED SEE data')
-
-    return
+# No cleaning, use standard warning function instead
+clean = mm_nasa.clean_warn
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Addresses #89, #118

Adds two general instrument methods which are frequently repeated:
- `init`, where the initialization routine reads from a standard mission-level module (cnofs, de2, icon)
- `clean_warn`, a custom clean routine that warns users that cleaning is not available

Additionally, suppresses logger messages during package-level imports of constellation objects.  This is required to keep the logger from being saturated until this issue is fixed at the pysat-level.  Otherwise verifying the logger here is near-impossible.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
import pysat
import logging
pysat.logger.setLevel(logging.INFO)
ivm = pysat.Instrument('cnofs', 'ivm')
```
acknowledgement string should go to the logger, and ivm.acknowledgements and ivm.references updated accordingly.

Can be repeated for the cnofs, de2, and icon instruments

For cleaning, attempt to load de2 data, look for the warning.

## Test Configuration
* Operating system: Mac OS X Big Sur
* Version number: python 3.8.11
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
