### PR TITLE
MAINT: add new custom mark

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,5 +59,6 @@ markers =
     all_inst: tests all instruments
     download: tests for downloadable instruments
     no_download: tests for instruments without download support
+    load_options: tests for instruments with additional options
     first: first tests to run
     second: second tests to run


### PR DESCRIPTION
# Description

Tidy up after #85.  New custom mark needed to be added to setup.cfg.  Noticed this while inspecting warnings in #100.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Via pytest

## Test Configuration
* Github actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes -- part of #85 
- [x] Update zenodo.json file for new code contributors
