### PR TITLE
STY: streamline cdf tests, NEP 29 update July 2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         numpy_ver: [latest]
         include:
           - python-version: "3.8"
-            numpy_ver: "1.19"
+            numpy_ver: "1.20"
             os: ubuntu-latest
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,16 +27,16 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install NEP29 dependencies
+      if: ${{ matrix.numpy_ver != 'latest'}}
+      run: |
+        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
+
     - name: Install standard dependencies
       run: |
         pip install -r requirements.txt
         pip install pysatCDF --no-binary=pysatCDF
         pip install -r test_requirements.txt
-
-    - name: Install NEP29 dependencies
-      if: ${{ matrix.numpy_ver != 'latest'}}
-      run: |
-        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
 
     - name: Set up pysat
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest --cov=pysatNASA/
+        pytest -vs --cov=pysatNASA/
 
     - name: Publish results to coveralls
       env:

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ some examples on how to use the routines
 
 pysatNASA uses common Python modules, as well as modules developed by
 and for the Space Physics community.  This module officially supports
-Python 3.7+.
+Python 3.8+.
 
-| Common modules | Community modules |
-| -------------- | ----------------- |
-| beautifulsoup4 | cdflib            |
-| lxml           | pysat>=3.0.2      |
-| netCDF4        |                   |
-| numpy          |                   |
-| pandas         |                   |
-| requests       |                   |
-| xarray         |                   |
+| Common modules   | Community modules |
+| ---------------- | ----------------- |
+| beautifulsoup4   | cdflib            |
+| lxml             | pysat>=3.0.2      |
+| netCDF4          |                   |
+| numpy            |                   |
+| pandas           |                   |
+| requests         |                   |
+| xarray<2022.06.0 |                   |
 
 ## GitHub Installation
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,17 +16,17 @@ pysatNASA uses common Python modules, as well as modules developed by
 and for the Space Physics community.  This module officially supports
 Python 3.7+ and pysat 3.0.0+.
 
- ================ =================
- Common modules   Community modules
- ================ =================
-  beautifulsoup4   cdflib>=0.4.4
-  lxml             pysat>=3.0.2
+ ================== =================
+ Common modules     Community modules
+ ================== =================
+  beautifulsoup4     cdflib>=0.4.4
+  lxml               pysat>=3.0.2
   netCDF4
   numpy
   pandas
   requests
-  xarray
- ================ =================
+  xarray>2022.06.0
+ ================== =================
 
 
 Installation Options

--- a/pysatNASA/tests/test_instruments.py
+++ b/pysatNASA/tests/test_instruments.py
@@ -41,15 +41,12 @@ class TestInstruments(clslib.InstLibTests):
     """
 
     @pytest.mark.second
-    @pytest.mark.parametrize("clean_level", ['none', 'dirty', 'dusty', 'clean'])
     @pytest.mark.parametrize("inst_dict", instruments['cdf'])
-    def test_load_cdflib(self, clean_level, inst_dict):
+    def test_load_cdflib(self, inst_dict):
         """Test that instruments load at each cleaning level.
 
         Parameters
         ----------
-        clean_level : str
-            Cleanliness level for loaded instrument data.
         inst_dict : dict
             Dictionary containing info to instantiate a specific instrument.
 
@@ -59,7 +56,6 @@ class TestInstruments(clslib.InstLibTests):
         files = test_inst.files.files
         if len(files) > 0:
             # Set Clean Level
-            test_inst.clean_level = clean_level
             target = 'Fake Data to be cleared'
             test_inst.data = [target]
             try:
@@ -79,10 +75,6 @@ class TestInstruments(clslib.InstLibTests):
 
             # Make sure fake data is cleared
             assert target not in test_inst.data
-            # If cleaning not used, something should be in the file
-            # Not used for clean levels since cleaning may remove all data
-            if clean_level == "none":
-                assert not test_inst.empty
         else:
             pytest.skip("Download data not available.")
 

--- a/pysatNASA/tests/test_instruments.py
+++ b/pysatNASA/tests/test_instruments.py
@@ -22,6 +22,13 @@ from pysat.tests.classes import cls_instrument_library as clslib
 instruments = clslib.InstLibTests.initialize_test_package(
     clslib.InstLibTests, inst_loc=pysatNASA.instruments)
 
+# Create a new list of instruments with the option of forcing cdflib
+instruments['cdf'] = []
+for inst in instruments['download']:
+    fname = inst['inst_module'].supported_tags[inst['inst_id']][inst['tag']]
+    if '.cdf' in fname:
+        instruments['cdf'].append(inst)
+
 
 class TestInstruments(clslib.InstLibTests):
     """Main class for instrument tests.
@@ -35,7 +42,7 @@ class TestInstruments(clslib.InstLibTests):
 
     @pytest.mark.second
     @pytest.mark.parametrize("clean_level", ['none', 'dirty', 'dusty', 'clean'])
-    @pytest.mark.parametrize("inst_dict", instruments['download'])
+    @pytest.mark.parametrize("inst_dict", instruments['cdf'])
     def test_load_cdflib(self, clean_level, inst_dict):
         """Test that instruments load at each cleaning level.
 
@@ -50,7 +57,7 @@ class TestInstruments(clslib.InstLibTests):
 
         test_inst, date = clslib.initialize_test_inst_and_date(inst_dict)
         files = test_inst.files.files
-        if len(files) > 0 and '.cdf' in files[0]:
+        if len(files) > 0:
             # Set Clean Level
             test_inst.clean_level = clean_level
             target = 'Fake Data to be cleared'
@@ -77,7 +84,6 @@ class TestInstruments(clslib.InstLibTests):
             if clean_level == "none":
                 assert not test_inst.empty
         else:
-            pytest.skip(" ".join(("Download data not available or instrument",
-                                  "does not use cdflib.")))
+            pytest.skip("Download data not available.")
 
         return

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ cdflib>=0.4.4
 numpy
 pandas
 pysat>=3.0.2
-xarray
+xarray<2022.06.0


### PR DESCRIPTION
# Description

- Improves `use_cdfib` syntax to reduce number of skipped tests.
- Bumps minimum NEP29 version to 1.20
- Adds xarray cap for incompatibilities with numpy 1.20
- Uses verbose pytest in Github Actions to get feedback on skipped tests

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested via pytest.

## Test Configuration
* Python 3.8.11
* Mac OS X Big Sur
* The usual tests at Github Actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes (part of previous pull, pysatCDF)
- [x] Update zenodo.json file for new code contributors
