### PR TITLE
MAINT: pandas and pysat deprecated syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Move OMNI HRO custom functions to a methods module
   * Deprecate OMNI HRO custom functions in instrument module
   * Update GitHub actions to the latest versions
+  * Remove deprecated `convert_timestamp_to_datetime` calls
+  * Remove deprecated pandas syntax
 * Documentation
   * New logo added
 

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -84,7 +84,6 @@ def preprocess(self, keep_original_names=False):
 
     """
 
-    mm_gen.convert_timestamp_to_datetime(self, sec_mult=1.0e-3)
     if not keep_original_names:
         mm_gen.remove_leading_text(self, target='ICON_L26_')
     return

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -85,7 +85,6 @@ def preprocess(self, keep_original_names=False):
 
     """
 
-    mm_gen.convert_timestamp_to_datetime(self, sec_mult=1.0e-3)
     if not keep_original_names:
         mm_icon.remove_preamble(self)
     return

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -105,7 +105,6 @@ def preprocess(self, keep_original_names=False):
 
     """
 
-    mm_gen.convert_timestamp_to_datetime(self, sec_mult=1.0e-3)
     if not keep_original_names:
         mm_icon.remove_preamble(self)
     return

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -455,7 +455,7 @@ def download(date_array, tag='', inst_id='', supported_tags=None,
                                      stop=date_array[-1])
 
     # Download only requested files that exist remotely
-    for date, fname in remote_files.iteritems():
+    for date, fname in remote_files.items():
         # Format files for specific dates and download location
         formatted_remote_dir = remote_dir.format(year=date.year,
                                                  month=date.month,


### PR DESCRIPTION
# Description

Addresses FutureWarnings from pandas.

Removes deprecated commands from pysat.  New pysat limits from other pulls means we no longer need backwards compatibility for these functions.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

inspecting tests and looking for warnings

Loading icon data to verify that time is in a datetime format.

## Test Configuration
* Operating system: all (GA)
* Version number: Python 3.8, 3.9, 3.10]

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
