### PR TITLE
GUVI

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -27,6 +27,11 @@
       {
         "name": "Spence, Carey",
         "orcid": "0000-0001-8340-5625"
+      },
+      {
+        "affilitation":"University of Colorado at Boulder",
+        "name": "Navarro, Luis",
+        "orcid": "0000-0002-6362-6575"
       }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.0.5] - 2022-11-12
+* New Instruments
+  * TIMED GUVI
+* Add TIMED GUVI platform to support L1C intensity datasets.
+  * Type of sensor source handled by inst_id with options of
+    spectrograph, imaging
+  * Resolution of dataset handled by tag with
+    low, high
+* Bug Fixes
+  * CDAWEB improved to consider cases of
+    remote directory structured by DOY instead of month/day combination
+    cadence of directory format consider yearly, monthly and daily cases.
+* Documentation
+  * Added TIMED-GUVI platform
+
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class
 * Support xarray datasets through cdflib

--- a/docs/supported_instruments.rst
+++ b/docs/supported_instruments.rst
@@ -130,6 +130,14 @@ SES14 GOLD
 .. automodule:: pysatNASA.instruments.ses14_gold
    :members:
 
+.. _timed_guvi:
+
+TIMED GUVI
+----------
+
+.. automodule:: pysatNASA.instruments.timed_guvi
+   :members:
+
 .. _timed_saber:
 
 TIMED SABER

--- a/pysatNASA/instruments/__init__.py
+++ b/pysatNASA/instruments/__init__.py
@@ -10,7 +10,7 @@ __all__ = ['cnofs_ivm', 'cnofs_plp', 'cnofs_vefi',
            'formosat1_ivm',
            'icon_euv', 'icon_fuv', 'icon_ivm', 'icon_mighti',
            'iss_fpmu', 'jpl_gps', 'omni_hro', 'ses14_gold',
-           'timed_saber', 'timed_see']
+           'timed_guvi', 'timed_saber', 'timed_see']
 
 for inst in __all__:
     exec("from pysatNASA.instruments import {x}".format(x=inst))

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -1,0 +1,353 @@
+# -*- coding: utf-8 -*-
+"""Supports the GUVI instrument on TIMED.
+
+Downloads data from the NASA Coordinated Data
+Analysis Web (CDAWeb).
+
+Supports two options for loading that may be
+specified at instantiation.
+
+Properties
+----------
+platform
+    'timed'
+name
+    'guvi'
+tag
+    'low'
+    'high'
+inst_id
+    'imaging'
+    'spectrograph'
+
+Note
+----
+No `inst_id` required.
+
+Warnings
+--------
+Currently no cleaning routine.
+
+
+Example
+-------
+::
+
+    import pysat
+    guvi = pysat.Instrument(platform='timed', name='guvi', inst_id='imaging', tag='low')
+    guvi.download(dt.datetime(2005, 6, 28), dt.datetime(2005, 6, 29))
+    guvi.load(yr=2005, doy=171)
+
+"""
+
+import datetime as dt
+import functools
+import numpy as np
+import warnings
+import xarray as xr
+
+import pysat
+from pysat.instruments.methods import general as mm_gen
+from pysat import logger
+
+from pysatNASA.instruments.methods import cdaweb as cdw
+
+# ----------------------------------------------------------------------------
+# Instrument attributes
+
+platform = 'timed'
+name = 'guvi'
+tags = {'high': 'Level 1C high resolution data',
+        'low': 'Level 1C low resolution data'}
+inst_ids = {'imaging': list(tags.keys()),
+            'spectrograph': list(tags.keys())}
+
+pandas_format = False
+
+# ----------------------------------------------------------------------------
+# Instrument test attributes
+
+_test_dates = {'imaging': {tag: dt.datetime(2005, 6, 28) for tag in tags.keys()},
+               'spectrograph': {tag: dt.datetime(2005, 6, 28) for tag in tags.keys()}}
+
+# ----------------------------------------------------------------------------
+# Instrument methods
+
+def init(self):
+    """Initialize the Instrument object with references and acknowledgements."""
+
+    rules_url = 'http://guvitimed.jhuapl.edu/home_guvi-datausage'
+    ackn_str = ' '.join(('Please see the Rules of the Road at', rules_url))
+    logger.info(ackn_str)
+    self.acknowledgements = ackn_str
+    self.references = ' '.join(('Paxton,L. J., Christensen, A. B., Humm,',
+                                'D. C., Ogorzalek, B. S., Pardoe, C. T.,',
+                                'Monison, D., Weiss, M. B., Cram, W.,',
+                                'Lew, P. H., Mabry, D. J., Goldstena,',
+                                'J. O., Gary, A., Persons, D. F., Harold,',
+                                'M. J., Alvarez, E. B., ErcoF, C. J.,',
+                                'Strickland, D. J., Meng, C.-I.',
+                                'Global ultraviolet imager (GUVI): Measuring',
+                                'composition and energy inputs for the NASA',
+                                'Thermosphere Ionosphere Mesosphere Energetics',
+                                'and Dynamics (TIMED) mission.',
+                                'Optical spectroscopic techniques and',
+                                'instrumentation for atmospheric and',
+                                'space research III. Vol. 3756.',
+                                'International Society for Optics',
+                                'and Photonics, 1999.'))
+
+    return
+
+
+def clean(self):
+    """Routine to return TIMED GUVI data cleaned to the specified level.
+
+    Note
+    ----
+    No cleaning currently available.
+
+    """
+    warnings.warn('no cleaning routines available for TIMED GUVI data')
+
+    return
+
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+#
+# Use the default CDAWeb and pysat methods
+# Set the list_files routine
+
+fname = ''.join(('TIMED_GUVI_L1C{res:s}-disk-{mode:s}_{{year:04d}}{{day:03d}}',
+                 '{{hour:02d}}{{minute:02d}}{{second:02d}}',
+                 '-?????????????_REV??????_',
+                 'Av{{version:02d}}-??r{{revision:03d}}.nc'))
+
+supported_tags = {inst: {tag: fname.format(res = "-2" if 'low' in tag else "",
+                                           mode = "IMG" if 'imag' in inst else "SPECT")
+                        for tag in tags.keys()}
+                 for inst in inst_ids}
+
+list_files = functools.partial(mm_gen.list_files,
+                               supported_tags=supported_tags,)
+
+# Set the download routine
+url = ''.join(('/pub/data/timed/guvi/levels_v13/level1c/{mode:s}/',
+               '{{year:4d}}/{{day:03d}}/'))
+
+supported_urls = {inst: {tag: url.format(mode=inst)
+                        for tag in tags.keys()}
+                 for inst in inst_ids}
+
+download_tags = {inst: {tag: {'remote_dir': supported_urls[inst][tag],
+                              'fname': supported_tags[inst][tag]}
+                       for tag in tags.keys()}
+                for inst in inst_ids.keys()}
+
+download = functools.partial(cdw.download, supported_tags=download_tags)
+
+# Set the list_remote_files routine
+list_remote_files = functools.partial(
+    cdw.list_remote_files, supported_tags=download_tags)
+
+
+# Set the load routine
+def load(fnames, tag='', inst_id=''):
+    """Load TIMED GUVI data into `xarray.DataSet` and `pysat.Meta` objects.
+
+    This routine is called as needed by pysat. It is not intended
+    for direct user interaction.
+
+    Parameters
+    ----------
+    fnames : array-like
+        iterable of filename strings, full path, to data files to be loaded.
+        This input is nominally provided by pysat itself.
+    tag : str
+        tag name used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    inst_id : str
+        Satellite ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+
+    Returns
+    -------
+    data : xr.DataSet
+        A xarray DataSet with data prepared for the pysat.Instrument
+    meta : pysat.Meta
+        Metadata formatted for a pysat.Instrument object.
+
+    Note
+    ----
+    Any additional keyword arguments passed to pysat.Instrument
+    upon instantiation are passed along to this routine.
+
+    Examples
+    --------
+    ::
+
+        inst = pysat.Instrument('timed', 'guvi', inst_id='imaging', tag='high')
+        inst.load(2005, 179)
+
+    """
+    labels = {'units': ('units', str), 'name': ('long_name', str),
+              'notes': ('notes', str), 'desc': ('desc', str),
+              'plot': ('plot_label', str), 'axis': ('axis', str),
+              'scale': ('scale', str),
+              'min_val': ('value_min', float),
+              'max_val': ('value_max', float),
+              'fill_val': ('fill', float)}
+    meta = pysat.Meta(labels=labels)
+
+    def get_dt_objects(dataset, tag):
+        dts = []
+        for i, year in enumerate(dataset['YEAR_%s' % tag].data):
+            idt = dt.datetime(year, 1, 1) + dt.timedelta(
+                days=float(dataset['DOY_%s' % tag].data[i] - 1),
+                seconds=float(dataset['TIME_%s' % tag].data[i]))
+            dts.append(idt)
+        return dts
+
+    # Dimensions for time variables
+    # night/day along, cross and time are the same imaging low, high, spectrograph low, high
+    # imaging high possess extra dims DayAur
+    # spectrograph low possess extra dims GAIMDay, GAIMNight
+    dims = ['time']
+    if 'imag' in inst_id:
+        dims = dims + ['time_auroral']
+    elif 'spect' in inst_id:
+        if 'low' in tag:
+            dims = dims + ['time_gaim_day', 'time_gaim_night']
+
+    # Separate and concatenate into datasets
+    inners = {dim: None for dim in dims}
+
+    for path in fnames:
+        data = xr.open_dataset(path, chunks='auto')
+
+        # Collect datetime objects
+        day_dts = np.array(get_dt_objects(data, "DAY"))
+        night_dts = np.array(get_dt_objects(data, "NIGHT"))
+        if 'imag' in inst_id:
+            aur_dts = get_dt_objects(data, "DAY_AURORAL")
+        elif 'spect' in inst_id:
+            if 'low' in tag:
+                gaimday_dts = get_dt_objects(data, "GAIM_DAY")
+                gaimnight_dts = get_dt_objects(data, "GAIM_NIGHT")
+
+        # Drop out redundant time variables
+        data = data.drop_vars(["YEAR_DAY", "DOY_DAY", "TIME_DAY", "TIME_EPOCH_DAY",
+                               "YEAR_NIGHT", "DOY_NIGHT",
+                               "TIME_NIGHT", "TIME_EPOCH_NIGHT"])
+        if 'imag' in inst_id:
+            data = data.drop_vars(["YEAR_DAY_AURORAL", "DOY_DAY_AURORAL",
+                                   "TIME_DAY_AURORAL", "TIME_EPOCH_DAY_AURORAL"])
+        elif 'spect' in inst_id:
+            if 'low' in tag:
+                data = data.drop_vars(["YEAR_GAIM_DAY", "DOY_GAIM_DAY",
+                                       "TIME_GAIM_DAY", "TIME_GAIM_NIGHT",
+                                       "YEAR_GAIM_NIGHT", "DOY_GAIM_NIGHT"])
+
+        if day_dts.size != night_dts.size:
+            raise Exception("nAlongDay & nAlongNight have different dimensions")
+
+        if np.any(day_dts != night_dts):
+            raise Exception("time along day and night are different")
+
+        # Renaming along/cross dimensions
+        data = data.rename_dims({"nAlongDay":"nAlong", "nAlongNight":"nAlong"})
+
+        # 'nCross' dimension only in imaging 
+        if 'imag' in inst_id:
+
+            if data.nCrossDay.size != data.nCrossNight.size:
+                raise Exception("nCrossDay/Night have different dimensions")
+
+            data = data.rename_dims({"nCrossDay":"nCross",
+                                     "nCrossNight":"nCross"})
+
+        # 'nAlong' will be renamed as 'time' to follow pysat standards
+        data = data.swap_dims({"nAlong": "time"})
+        if 'imag' in inst_id:
+            data = data.swap_dims({"nAlongDayAur": "time_auroral"})
+        elif 'spect' in inst_id:
+            if 'low' in tag:
+                data = data.swap_dims({"nAlongGAIMDay": "time_gaim_day",
+                                       "nAlongGAIMNight": "time_gaim_night"})
+
+        # Update time variables
+        # night_dts and day_dts are the same temporal array 
+        data = data.assign(time=night_dts)
+        if 'imag' in inst_id:
+            data = data.assign(time_auroral=aur_dts)
+        elif 'spect' in inst_id:
+            if 'low' in tag:
+                data = data.assign(time_gaim_day=gaimday_dts,
+                                   time_gaim_night=gaimnight_dts)
+
+        # Separate into inner datasets
+        inner_keys = {dim: [] for dim in dims}
+
+        for dim in dims:
+            for key in data.keys():
+                if dim in data[key].dims:
+                    inner_keys[dim].append(key)
+
+        jnners = {dim: data.get(inner_keys[dim]) for dim in dims}
+
+        # Add 'single_var's into 'time' dataset to keep track
+        sv_keys = [v.name for v in data.values() if 'single_var' in v.dims]
+        singlevar_set = data.get(sv_keys)
+        jnners['time'] = xr.merge([jnners['time'], singlevar_set])
+
+        # Concatenate along corresponding dimension
+        if inners['time'] is None:
+            inners = jnners
+        else:
+            inners = {dim : xr.concat([inners[dim], jnners[dim]], dim=dim)
+                      for dim in dims }
+
+    data = xr.merge([inners[dim] for dim in dims])
+
+    # Set up coordinates
+    coords = ['PIERCEPOINT_NIGHT_LATITUDE',
+              'PIERCEPOINT_NIGHT_LONGITUDE',
+              'PIERCEPOINT_NIGHT_ALTITUDE',
+              'PIERCEPOINT_NIGHT_SZA',
+              'PIERCEPOINT_DAY_LATITUDE',
+              'PIERCEPOINT_DAY_LONGITUDE',
+              'PIERCEPOINT_DAY_ALTITUDE',
+              'PIERCEPOINT_DAY_SZA']
+
+    if 'imag' in inst_id:
+        coords = coords + ['PIERCEPOINT_DAY_LATITUDE_AURORAL',
+                           'PIERCEPOINT_DAY_LONGITUDE_AURORAL',
+                           'PIERCEPOINT_DAY_ALTITUDE_AURORAL',
+                           'PIERCEPOINT_DAY_SZA_AURORAL']
+    elif 'spect' in inst_id:
+        coords = coords + ['PIERCEPOINT_NIGHT_ZENITH_ANGLE',
+                           'PIERCEPOINT_NIGHT_SAZIMUTH',
+                           'PIERCEPOINT_DAY_ZENITH_ANGLE',
+                           'PIERCEPOINT_DAY_SAZIMUTH']
+
+    data = data.set_coords(coords)
+
+    # Set 'nchan' and 'nCross' as coordinates
+    if 'imag' in inst_id:
+        coords = {"nchan": ["121.6nm", "130.4nm", "135.6nm",
+                            "LBHshort", "LBHlong"],
+                  "nchanAur": ["121.6nm", "130.4nm", "135.6nm",
+                               "LBHshort", "LBHlong"],
+                  "nCross": data.nCross.data,
+                  "nCrossDayAur": data.nCrossDayAur.data}
+    elif 'spect' in inst_id:
+        coords = {"nchan": ["121.6nm", "130.4nm", "135.6nm",
+                            "LBHshort", "LBHlong","?"]}
+
+    data = data.assign_coords(coords=coords)
+
+    # Sort
+    data = data.sortby("time")
+
+    return data, meta

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -66,8 +66,9 @@ pandas_format = False
 # ----------------------------------------------------------------------------
 # Instrument test attributes
 
-_test_dates = {'imaging': {tag: dt.datetime(2005, 6, 28) for tag in tags.keys()},
-               'spectrograph': {tag: dt.datetime(2005, 6, 28) for tag in tags.keys()}}
+_test_dates = {
+    'imaging': {tag: dt.datetime(2005, 6, 28) for tag in tags.keys()},
+    'spectrograph': {tag: dt.datetime(2005, 6, 28) for tag in tags.keys()}}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -278,7 +278,7 @@ def load(fnames, tag='', inst_id=''):
                                        "nAlongGAIMNight": "time_gaim_night"})
 
         # Update time variables
-        # night_dts and day_dts are the same temporal array 
+        # night_dts and day_dts are the same temporal array
         data = data.assign(time=night_dts)
         if 'imag' in inst_id:
             data = data.assign(time_auroral=aur_dts)

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -29,7 +29,7 @@ Example
 ::
 
     import pysat
-    guvi = pysat.Instrument(platform='timed', name='guvi', inst_id='imaging', 
+    guvi = pysat.Instrument(platform='timed', name='guvi', inst_id='imaging',
                             tag='low')
     guvi.download(dt.datetime(2005, 6, 28), dt.datetime(2005, 6, 29))
     guvi.load(date=dt.datetime(2005, 6, 28))

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -140,8 +140,8 @@ supported_urls = {inst: {tag: url.format(mode=inst)
 
 download_tags = {inst: {tag: {'remote_dir': supported_urls[inst][tag],
                               'fname': supported_tags[inst][tag]}
-                       for tag in tags.keys()}
-                for inst in inst_ids.keys()}
+                        for tag in tags.keys()}
+                 for inst in inst_ids.keys()}
 
 download = functools.partial(cdw.download, supported_tags=download_tags)
 

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -259,7 +259,7 @@ def load(fnames, tag='', inst_id=''):
         data = data.rename_dims({"nAlongDay": "nAlong",
                                  "nAlongNight": "nAlong"})
 
-        # 'nCross' dimension only in imaging 
+        # 'nCross' dimension only in imaging
         if 'imag' in inst_id:
 
             if data.nCrossDay.size != data.nCrossNight.size:

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -241,7 +241,8 @@ def load(fnames, tag='', inst_id=''):
                                "TIME_NIGHT", "TIME_EPOCH_NIGHT"])
         if 'imag' in inst_id:
             data = data.drop_vars(["YEAR_DAY_AURORAL", "DOY_DAY_AURORAL",
-                                   "TIME_DAY_AURORAL", "TIME_EPOCH_DAY_AURORAL"])
+                                   "TIME_DAY_AURORAL",
+                                   "TIME_EPOCH_DAY_AURORAL"])
         elif 'spect' in inst_id:
             if 'low' in tag:
                 data = data.drop_vars(["YEAR_GAIM_DAY", "DOY_GAIM_DAY",

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -135,7 +135,7 @@ list_files = functools.partial(mm_gen.list_files,
 url = ''.join(('/pub/data/timed/guvi/levels_v13/level1c/{mode:s}/',
                '{{year:4d}}/{{day:03d}}/'))
 
-supported_urls = {inst: {tag: url.format(mode=tag)
+supported_urls = {inst: {tag: url.format(mode=tag.split('-')[1])
                          for tag in tags.keys()}
                   for inst in inst_ids}
 

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -14,8 +14,8 @@ platform
 name
     'guvi'
 tag
-    'imaging'
-    'spectrograph'
+    'sdr-imaging'
+    'sdr-spectrograph'
 inst_id
     'high_res'
     'low_res'
@@ -29,8 +29,8 @@ Example
 ::
 
     import pysat
-    guvi = pysat.Instrument(platform='timed', name='guvi', inst_id='imaging',
-                            tag='low')
+    guvi = pysat.Instrument(platform='timed', name='guvi',
+                            inst_id='sdr-imaging', tag='low_res')
     guvi.download(dt.datetime(2005, 6, 28), dt.datetime(2005, 6, 29))
     guvi.load(date=dt.datetime(2005, 6, 28))
 
@@ -53,8 +53,8 @@ from pysatNASA.instruments.methods import cdaweb as cdw
 
 platform = 'timed'
 name = 'guvi'
-tags = {'imaging': 'Level 1C imaging data',
-        'spectrograph': 'Level 1C spectrograph data'}
+tags = {'sdr-imaging': 'Level 1C imaging data',
+        'sdr-spectrograph': 'Level 1C spectrograph data'}
 inst_ids = {'high_res': list(tags.keys()),
             'low_res': list(tags.keys())}
 
@@ -123,7 +123,7 @@ fname = ''.join(('TIMED_GUVI_L1C{res:s}-disk-{mode:s}_{{year:04d}}{{day:03d}}',
                  'Av{{version:02d}}-??r{{revision:03d}}.nc'))
 
 res = {'low_res': '-2', 'high_res': ''}
-mode = {'imaging': 'IMG', 'spectrograph': 'SPECT'}
+mode = {'sdr-imaging': 'IMG', 'sdr-spectrograph': 'SPECT'}
 supported_tags = {inst: {tag: fname.format(res=res[inst], mode=mode[tag])
                          for tag in tags.keys()}
                   for inst in inst_ids}
@@ -186,7 +186,8 @@ def load(fnames, tag='', inst_id=''):
     --------
     ::
 
-        inst = pysat.Instrument('timed', 'guvi', inst_id='high_res', tag='imaging')
+        inst = pysat.Instrument('timed', 'guvi',
+                                inst_id='high_res', tag='sdr-imaging')
         inst.load(2005, 179)
 
     """
@@ -214,9 +215,9 @@ def load(fnames, tag='', inst_id=''):
     # imaging high_res also has dims DayAur
     # spectrograph low_res also has dims GAIMDay, GAIMNight
     dims = ['time']
-    if 'imag' in tag:
+    if 'sdr-imag' in tag:
         dims = dims + ['time_auroral']
-    elif 'spect' in tag:
+    elif 'sdr-spect' in tag:
         if 'low' in inst_id:
             dims = dims + ['time_gaim_day', 'time_gaim_night']
 
@@ -229,9 +230,9 @@ def load(fnames, tag='', inst_id=''):
         # Collect datetime objects
         day_dts = np.array(get_dt_objects(data, "DAY"))
         night_dts = np.array(get_dt_objects(data, "NIGHT"))
-        if 'imag' in tag:
+        if 'sdr-imag' in tag:
             aur_dts = get_dt_objects(data, "DAY_AURORAL")
-        elif 'spect' in tag:
+        elif 'sdr-spect' in tag:
             if 'low' in inst_id:
                 gaimday_dts = get_dt_objects(data, "GAIM_DAY")
                 gaimnight_dts = get_dt_objects(data, "GAIM_NIGHT")
@@ -240,11 +241,11 @@ def load(fnames, tag='', inst_id=''):
         data = data.drop_vars(["YEAR_DAY", "DOY_DAY", "TIME_DAY",
                                "TIME_EPOCH_DAY", "YEAR_NIGHT", "DOY_NIGHT",
                                "TIME_NIGHT", "TIME_EPOCH_NIGHT"])
-        if 'imag' in tag:
+        if 'sdr-imag' in tag:
             data = data.drop_vars(["YEAR_DAY_AURORAL", "DOY_DAY_AURORAL",
                                    "TIME_DAY_AURORAL",
                                    "TIME_EPOCH_DAY_AURORAL"])
-        elif 'spect' in tag:
+        elif 'sdr-spect' in tag:
             if 'low' in inst_id:
                 data = data.drop_vars(["YEAR_GAIM_DAY", "DOY_GAIM_DAY",
                                        "TIME_GAIM_DAY", "TIME_GAIM_NIGHT",
@@ -261,7 +262,7 @@ def load(fnames, tag='', inst_id=''):
                                  "nAlongNight": "nAlong"})
 
         # 'nCross' dimension only in imaging
-        if 'imag' in tag:
+        if 'sdr-imag' in tag:
 
             if data.nCrossDay.size != data.nCrossNight.size:
                 raise Exception("nCrossDay/Night have different dimensions")
@@ -271,9 +272,9 @@ def load(fnames, tag='', inst_id=''):
 
         # 'nAlong' will be renamed as 'time' to follow pysat standards
         data = data.swap_dims({"nAlong": "time"})
-        if 'imag' in tag:
+        if 'sdr-imag' in tag:
             data = data.swap_dims({"nAlongDayAur": "time_auroral"})
-        elif 'spect' in tag:
+        elif 'sdr-spect' in tag:
             if 'low' in inst_id:
                 data = data.swap_dims({"nAlongGAIMDay": "time_gaim_day",
                                        "nAlongGAIMNight": "time_gaim_night"})
@@ -281,9 +282,9 @@ def load(fnames, tag='', inst_id=''):
         # Update time variables
         # night_dts and day_dts are the same temporal array
         data = data.assign(time=night_dts)
-        if 'imag' in tag:
+        if 'sdr-imag' in tag:
             data = data.assign(time_auroral=aur_dts)
-        elif 'spect' in tag:
+        elif 'sdr-spect' in tag:
             if 'low' in inst_id:
                 data = data.assign(time_gaim_day=gaimday_dts,
                                    time_gaim_night=gaimnight_dts)
@@ -322,12 +323,12 @@ def load(fnames, tag='', inst_id=''):
               'PIERCEPOINT_DAY_ALTITUDE',
               'PIERCEPOINT_DAY_SZA']
 
-    if 'imag' in tag:
+    if 'sdr-imag' in tag:
         coords = coords + ['PIERCEPOINT_DAY_LATITUDE_AURORAL',
                            'PIERCEPOINT_DAY_LONGITUDE_AURORAL',
                            'PIERCEPOINT_DAY_ALTITUDE_AURORAL',
                            'PIERCEPOINT_DAY_SZA_AURORAL']
-    elif 'spect' in tag:
+    elif 'sdr-spect' in tag:
         coords = coords + ['PIERCEPOINT_NIGHT_ZENITH_ANGLE',
                            'PIERCEPOINT_NIGHT_SAZIMUTH',
                            'PIERCEPOINT_DAY_ZENITH_ANGLE',
@@ -336,14 +337,14 @@ def load(fnames, tag='', inst_id=''):
     data = data.set_coords(coords)
 
     # Set 'nchan' and 'nCross' as coordinates
-    if 'imag' in tag:
+    if 'sdr-imag' in tag:
         coords = {"nchan": ["121.6nm", "130.4nm", "135.6nm",
                             "LBHshort", "LBHlong"],
                   "nchanAur": ["121.6nm", "130.4nm", "135.6nm",
                                "LBHshort", "LBHlong"],
                   "nCross": data.nCross.data,
                   "nCrossDayAur": data.nCrossDayAur.data}
-    elif 'spect' in tag:
+    elif 'sdr-spect' in tag:
         coords = {"nchan": ["121.6nm", "130.4nm", "135.6nm",
                             "LBHshort", "LBHlong", "?"]}
 

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -256,7 +256,8 @@ def load(fnames, tag='', inst_id=''):
             raise Exception("time along day and night are different")
 
         # Renaming along/cross dimensions
-        data = data.rename_dims({"nAlongDay":"nAlong", "nAlongNight":"nAlong"})
+        data = data.rename_dims({"nAlongDay": "nAlong",
+                                 "nAlongNight": "nAlong"})
 
         # 'nCross' dimension only in imaging 
         if 'imag' in inst_id:

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -22,12 +22,10 @@ inst_id
 
 Note
 ----
-No `inst_id` required.
 
 Warnings
 --------
 Currently no cleaning routine.
-
 
 Example
 -------

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -35,7 +35,7 @@ Example
     guvi = pysat.Instrument(platform='timed', name='guvi', inst_id='imaging', 
                             tag='low')
     guvi.download(dt.datetime(2005, 6, 28), dt.datetime(2005, 6, 29))
-    guvi.load(yr=2005, doy=171)
+    guvi.load(date=dt.datetime(2005, 6, 28))
 
 """
 

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -32,7 +32,8 @@ Example
 ::
 
     import pysat
-    guvi = pysat.Instrument(platform='timed', name='guvi', inst_id='imaging', tag='low')
+    guvi = pysat.Instrument(platform='timed', name='guvi', inst_id='imaging', 
+                            tag='low')
     guvi.download(dt.datetime(2005, 6, 28), dt.datetime(2005, 6, 29))
     guvi.load(yr=2005, doy=171)
 

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -208,7 +208,8 @@ def load(fnames, tag='', inst_id=''):
         return dts
 
     # Dimensions for time variables
-    # night/day along, cross and time are the same imaging low, high, spectrograph low, high
+    # night/day along, cross and time are the same imaging low, high,
+    #    spectrograph low, high
     # imaging high possess extra dims DayAur
     # spectrograph low possess extra dims GAIMDay, GAIMNight
     dims = ['time']

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -138,8 +138,8 @@ url = ''.join(('/pub/data/timed/guvi/levels_v13/level1c/{mode:s}/',
                '{{year:4d}}/{{day:03d}}/'))
 
 supported_urls = {inst: {tag: url.format(mode=inst)
-                        for tag in tags.keys()}
-                 for inst in inst_ids}
+                         for tag in tags.keys()}
+                  for inst in inst_ids}```
 
 download_tags = {inst: {tag: {'remote_dir': supported_urls[inst][tag],
                               'fname': supported_tags[inst][tag]}

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -238,7 +238,7 @@ def load(fnames, tag='', inst_id=''):
 
         # Drop out redundant time variables
         data = data.drop_vars(["YEAR_DAY", "DOY_DAY", "TIME_DAY",
-                               "TIME_EPOCH_DAY", "YEAR_NIGHT", "DOY_NIGHT"
+                               "TIME_EPOCH_DAY", "YEAR_NIGHT", "DOY_NIGHT",
                                "TIME_NIGHT", "TIME_EPOCH_NIGHT"])
         if 'imag' in inst_id:
             data = data.drop_vars(["YEAR_DAY_AURORAL", "DOY_DAY_AURORAL",

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -136,7 +136,7 @@ url = ''.join(('/pub/data/timed/guvi/levels_v13/level1c/{mode:s}/',
 
 supported_urls = {inst: {tag: url.format(mode=inst)
                          for tag in tags.keys()}
-                  for inst in inst_ids}```
+                  for inst in inst_ids}
 
 download_tags = {inst: {tag: {'remote_dir': supported_urls[inst][tag],
                               'fname': supported_tags[inst][tag]}

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -70,6 +70,7 @@ _test_dates = {
 # ----------------------------------------------------------------------------
 # Instrument methods
 
+
 def init(self):
     """Initialize the Instrument object with references and acknowledgements."""
 

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -53,10 +53,10 @@ from pysatNASA.instruments.methods import cdaweb as cdw
 
 platform = 'timed'
 name = 'guvi'
-tags = {'high': 'Level 1C high resolution data',
-        'low': 'Level 1C low resolution data'}
-inst_ids = {'imaging': list(tags.keys()),
-            'spectrograph': list(tags.keys())}
+tags = {'imaging': 'Level 1C imaging data',
+        'spectrograph': 'Level 1C spectrograph data'}
+inst_ids = {'high_res': list(tags.keys()),
+            'low_res': list(tags.keys())}
 
 pandas_format = False
 

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -344,7 +344,7 @@ def load(fnames, tag='', inst_id=''):
                   "nCrossDayAur": data.nCrossDayAur.data}
     elif 'spect' in inst_id:
         coords = {"nchan": ["121.6nm", "130.4nm", "135.6nm",
-                            "LBHshort", "LBHlong","?"]}
+                            "LBHshort", "LBHlong", "?"]}
 
     data = data.assign_coords(coords=coords)
 

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -236,8 +236,8 @@ def load(fnames, tag='', inst_id=''):
                 gaimnight_dts = get_dt_objects(data, "GAIM_NIGHT")
 
         # Drop out redundant time variables
-        data = data.drop_vars(["YEAR_DAY", "DOY_DAY", "TIME_DAY", "TIME_EPOCH_DAY",
-                               "YEAR_NIGHT", "DOY_NIGHT",
+        data = data.drop_vars(["YEAR_DAY", "DOY_DAY", "TIME_DAY",
+                               "TIME_EPOCH_DAY", "YEAR_NIGHT", "DOY_NIGHT"
                                "TIME_NIGHT", "TIME_EPOCH_NIGHT"])
         if 'imag' in inst_id:
             data = data.drop_vars(["YEAR_DAY_AURORAL", "DOY_DAY_AURORAL",

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -124,10 +124,11 @@ fname = ''.join(('TIMED_GUVI_L1C{res:s}-disk-{mode:s}_{{year:04d}}{{day:03d}}',
                  '-?????????????_REV??????_',
                  'Av{{version:02d}}-??r{{revision:03d}}.nc'))
 
-supported_tags = {inst: {tag: fname.format(res = "-2" if 'low' in tag else "",
-                                           mode = "IMG" if 'imag' in inst else "SPECT")
-                        for tag in tags.keys()}
-                 for inst in inst_ids}
+res = {'low': '-2', 'high': ''}
+mode = {'imaging': 'IMG', 'spectrograph': 'SPECT'}
+supported_tags = {inst: {tag: fname.format(res=res[tag], mode=mode[inst])
+                         for tag in tags.keys()}
+                  for inst in inst_ids}
 
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags,)

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -265,8 +265,8 @@ def load(fnames, tag='', inst_id=''):
             if data.nCrossDay.size != data.nCrossNight.size:
                 raise Exception("nCrossDay/Night have different dimensions")
 
-            data = data.rename_dims({"nCrossDay":"nCross",
-                                     "nCrossNight":"nCross"})
+            data = data.rename_dims({"nCrossDay": "nCross",
+                                     "nCrossNight": "nCross"})
 
         # 'nAlong' will be renamed as 'time' to follow pysat standards
         data = data.swap_dims({"nAlong": "time"})

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -306,8 +306,8 @@ def load(fnames, tag='', inst_id=''):
         if inners['time'] is None:
             inners = jnners
         else:
-            inners = {dim : xr.concat([inners[dim], jnners[dim]], dim=dim)
-                      for dim in dims }
+            inners = {dim: xr.concat([inners[dim], jnners[dim]], dim=dim)
+                      for dim in dims}
 
     data = xr.merge([inners[dim] for dim in dims])
 

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -20,9 +20,6 @@ inst_id
     'imaging'
     'spectrograph'
 
-Note
-----
-
 Warnings
 --------
 Currently no cleaning routine.


### PR DESCRIPTION
Support for TIMED-GUVI L1C intensity datasets.

# Description
Spectrograph and imaging sensors handled by inst_id, and resolutions handled by tags of high and low.

Addresses # (issue)
-Added platform TIMED and instruments for GUVI L1C datasets.
-Methods of load and download included and tested.
-cdaweb was improved to consider cases found in GUVI:
 * remote directory uses doy only instead of day/month combinations
 * cadence of directory format is now for yearly, monthly, and daily (when using doy).
-platform was added into documentation
-platform was added in __init__ for registration

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

It was tested following pysat guidelines using pytest -vs -flake8 pysatNASA

## Test Configuration
* Operating system: [macosx]
* Version number: [Python 3.8]
* locally installed using conda

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
