### PR TITLE
STY: version cap on numpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.0.5] - 2023-XX-XX
 * Maintenance
-  * Added a version cap for numpy (required by pysatCDF, revisit before release)
+  * Added a version cap for numpy (required for cdf interface, revisit before release)
 
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.0.5] - 2023-XX-XX
+* Maintenance
+  * Added a version cap for numpy (required by pysatCDF, revisit before release)
+
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class
 * Support xarray datasets through cdflib

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests
 beautifulsoup4
 lxml
 cdflib>=0.4.4
-numpy
+numpy<1.24
 pandas
 pysat>=3.0.4
 xarray<2022.11


### PR DESCRIPTION
# Description

The cdf interface doesn't like numpy 1.24.0.  I see some issues with both cdflib and pysatCDF.  Adds a version cap here to fix this for the time being.

Specific failures documented at #142 and https://github.com/pysat/pysatCDF/issues/46

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Github Actions and local tests.

## Test Configuration
Github Actions suite.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
