### PR TITLE
Cdasws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.0.5] - 2023-XX-XX
+* Added cdaweb methods that can use cdasws to get the remote file list
+
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class
 * Support xarray datasets through cdflib

--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -245,12 +245,9 @@ list_files = functools.partial(mm_gen.list_files,
 # Set the load routine
 load = cdw.load
 
-# Set the download routine
-basic_tag = {'remote_dir': '/pub/data/cnofs/cindi/ivm_500ms_cdf/{year:4d}/',
-             'fname': fname}
-download_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'': 'CNOFS_CINDI_IVM_500MS'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -119,11 +119,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # Set the download routine
-basic_tag = {'remote_dir': '/pub/data/cnofs/plp/plasma_1sec/{year:4d}/',
-             'fname': fname}
-download_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'': 'CNOFS_PLP_PLASMA_1SEC'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -122,11 +122,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # Set the download routine
-basic_tag = {'remote_dir': '/pub/data/cnofs/vefi/bfield_1sec/{year:4d}/',
-             'fname': fname}
-download_tags = {'': {'dc_b': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'dc_b': 'CNOFS_VEFI_BFIELD_1SEC'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -97,12 +97,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # Set the download routine
-basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/plasma_lang',
-                                    '/plasma500ms_lang_cdaweb/{year:4d}/')),
-             'fname': fname}
-download_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'': 'DE2_PLASMA500MS_LANG'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -120,12 +120,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # Support download routine
-basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/neutral_gas_nacs',
-                                    '/neutral1s_nacs_cdaweb/{year:4d}/')),
-             'fname': fname}
-download_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'': 'DE2_NEUTRAL1S_NACS'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Support listing files currently on CDAWeb
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -106,12 +106,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # Set the download routine
-basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/plasma_rpa',
-                                    '/ion2s_cdaweb/{year:4d}/')),
-             'fname': fname}
-download_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'': 'DE2_ION2S_RPA'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -117,12 +117,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # Set the download routine
-basic_tag = {'remote_dir': ''.join(('/pub/data/de/de2/neutral_gas_wats',
-                                    '/wind2s_wats_cdaweb/{year:4d}/')),
-             'fname': fname}
-download_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'': 'DE2_WIND2S_WATS'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)

--- a/pysatNASA/instruments/formosat1_ivm.py
+++ b/pysatNASA/instruments/formosat1_ivm.py
@@ -92,12 +92,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # Set the download routine
-basic_tag = {'remote_dir': ''.join(('/pub/data/formosat-rocsat/formosat-1',
-                                    '/ipei/{year:4d}/')),
-             'fname': fname}
-download_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'': 'RS_K0_IPEI'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -127,13 +127,11 @@ list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # Set the download routine
-basic_tag = {'remote_dir': '/pub/data/icon/l2/l2-6_euv/{year:04d}/',
-             'fname': fname}
-download_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'': 'ICON_L2-6_EUV'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)
 
 

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -118,17 +118,19 @@ supported_tags = {'': {'day': fname24, 'night': fname25}}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
-# Set the download routine
-basic_tag24 = {'remote_dir': '/pub/data/icon/l2/l2-4_fuv_day/{year:04d}/',
-               'fname': fname24}
-basic_tag25 = {'remote_dir': '/pub/data/icon/l2/l2-5_fuv_night/{year:04d}/',
-               'fname': fname25}
-download_tags = {'': {'day': basic_tag24, 'night': basic_tag25}}
+# old Set the download routine
+# basic_tag24 = {'remote_dir': '/pub/data/icon/l2/l2-4_fuv_day/{year:04d}/',
+#                'fname': fname24}
+# basic_tag25 = {'remote_dir': '/pub/data/icon/l2/l2-5_fuv_night/{year:04d}/',
+#                'fname': fname25}
+# download_tags = {'': {'day': basic_tag24, 'night': basic_tag25}}
+download_tags = {'': {'day': 'ICON_L2-5_FUV_DAY',
+                      'night': 'ICON_L2-5_FUV_NIGHT'}}
 
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)
 
 

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -192,13 +192,12 @@ list_files = functools.partial(mm_gen.list_files,
 
 # Set the download routine
 dirstr = '/pub/data/icon/l2/l2-7_ivm-{id:s}/{{year:4d}}/'
-download_tags = {id: {'': {'remote_dir': dirstr.format(id=id),
-                           'fname': supported_tags[id]['']}}
-                 for id in ['a', 'b']}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'a': {'': 'ICON_L2-7_IVM-A'}, 'b': {'': 'ICON_L2-7_IVM-B'}}
+
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)
 
 

--- a/pysatNASA/instruments/iss_fpmu.py
+++ b/pysatNASA/instruments/iss_fpmu.py
@@ -115,12 +115,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # Set the download routine
-basic_tag = {'remote_dir': ''.join(('/pub/data/international_space_station_iss',
-                                    '/sp_fpmu/{year:4d}/')),
-             'fname': fname}
-download_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'': 'ISS_SP_FPMU'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -46,7 +46,6 @@ import warnings
 
 from pysat.instruments.methods import general as mm_gen
 from pysat import logger
-from pysat.utils import time as pysat_time
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import omni as mm_omni
@@ -140,59 +139,12 @@ list_files = functools.partial(mm_gen.list_files,
                                file_cadence=pds.DateOffset(months=1))
 
 # Set the list_remote_files routine
-remote_dir = '/pub/data/omni/omni_cdaweb/hro_{tag:s}/{{year:4d}}/'
-download_tags = {inst_id: {tag: {'remote_dir': remote_dir.format(tag=tag),
-                                 'fname': supported_tags[inst_id][tag]}
-                           for tag in tags.keys()}
-                 for inst_id in inst_ids.keys()}
-list_remote_files = functools.partial(cdw.list_remote_files,
+download_tags = {'': {'1min': 'OMNI_HRO_1MIN', '5min': 'OMNI_HRO_5MIN'}}
+download = functools.partial(cdw.cdas_download,
+                             supported_tags=download_tags)
+
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)
-
-
-# Set the download routine
-def download(date_array, tag, inst_id, data_path, update_files=False):
-    """Download OMNI HRO data from CDAWeb.
-
-    Parameters
-    ----------
-    date_array : array-like
-        Sequence of dates for which files will be downloaded.
-    tag : str
-        Denotes type of file to load.
-    inst_id : str
-        Specifies the satellite ID for a constellation.
-    data_path : str
-        Path to data directory.
-    update_files : bool
-        Re-download data for files that already exist if True (default=False)
-
-    Raises
-    ------
-    IOError
-        If a problem is encountered connecting to the gateway or retrieving
-        data from the repository.
-
-    Warnings
-    --------
-    Only able to download current forecast data, not archived forecasts.
-
-    Note
-    ----
-    Called by pysat. Not intended for direct use by user.
-
-    """
-
-    # Set the download tags
-
-    # Adjust the date_array for monthly downloads
-    if date_array.freq != 'MS':
-        date_array = pysat_time.create_date_range(
-            dt.datetime(date_array[0].year, date_array[0].month, 1),
-            date_array[-1], freq='MS')
-
-    cdw.download(date_array, tag=tag, inst_id=inst_id,
-                 supported_tags=download_tags, data_path=data_path)
-    return
 
 
 # Set the load routine

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -104,15 +104,11 @@ list_files = functools.partial(ps_gen.list_files,
                                supported_tags=supported_tags)
 
 # Set the download routine
-download_tags = {inst_id:
-                 {tag: {'remote_dir': ''.join(('/pub/data/gold/level2/', tag,
-                                               '/{year:4d}/')),
-                        'fname': supported_tags[''][tag]}
-                  for tag in tags.keys()} for inst_id in inst_ids.keys()}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'nmax': 'GOLD_L2_NMAX'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)
 
 

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -117,12 +117,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = cdw.load
 
 # Set the download routine
-basic_tag = {'remote_dir': ''.join(('/pub/data/timed/saber/level2a_cdf',
-                                    '/{year:4d}/{month:02d}/')),
-             'fname': fname}
-download_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'': 'TIMED_L2A_SABER'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -107,12 +107,9 @@ list_files = functools.partial(mm_gen.list_files,
 load = functools.partial(cdw.load, file_cadence=pds.DateOffset(months=1))
 
 # Set the download routine
-basic_tag = {'remote_dir': ''.join(('/pub/data/timed/see/data/level3a_cdf',
-                                    '/{year:4d}/{month:02d}/')),
-             'fname': fname}
-download_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=download_tags)
+download_tags = {'': {'': 'TIMED_L3A_SEE'}}
+download = functools.partial(cdw.cdas_download, supported_tags=download_tags)
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(cdw.list_remote_files,
+list_remote_files = functools.partial(cdw.cdas_list_remote_files,
                                       supported_tags=download_tags)

--- a/pysatNASA/tests/test_methods_cdaweb.py
+++ b/pysatNASA/tests/test_methods_cdaweb.py
@@ -16,7 +16,7 @@ class TestCDAWeb(object):
     def setup_method(self):
         """Set up the unit test environment for each method."""
 
-        self.download_tags = pysatNASA.instruments.cnofs_plp.download_tags
+        self.download_tags = pysatNASA.instruments.icon_mighti.download_tags
         self.kwargs = {'tag': None, 'inst_id': None}
         return
 
@@ -31,7 +31,7 @@ class TestCDAWeb(object):
 
         with pytest.raises(Exception) as excinfo:
             # Giving a bad remote_site address yields similar ConnectionError
-            cdw.list_remote_files(tag='', inst_id='',
+            cdw.list_remote_files(tag='los_wind_green', inst_id='a',
                                   supported_tags=self.download_tags,
                                   remote_url='https://bad/path')
 


### PR DESCRIPTION
# Description
Adds support to use cdasws to get the remote file list for pysatNASA instruments.

Addresses #134 

The cdasws api is very robust when it comes to getting the remote file list, and doesn't need the file cadence to be specified. 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change may require a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- local pytest and flake8

## Test Configuration
* Operating system: [MacOS]
* Version number: [Python 3.9.15]
* conda virtual environment

# Checklist:

- [X] Make sure you are merging into the ``develop`` (not ``main``) branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Add a note to ``CHANGELOG.md``, summarizing the changes
- [X] Update zenodo.json file for new code contributors
