### PR TITLE
ENH: DMSP SSUSI EDR-Aurora Instrument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.0.5] - 2023-XX-XX
+* New Instruments
+  * DMSP SSUSI EDR-Aurora data
+* Bug Fixes
+  * Updated CDAWeb routines to allow for data stored by year/day-of-year
 * Maintenance
   * Added a version cap for numpy (required for cdf interface, revisit before release)
 

--- a/docs/supported_instruments.rst
+++ b/docs/supported_instruments.rst
@@ -57,6 +57,14 @@ DE2 WATS
 .. automodule:: pysatNASA.instruments.de2_wats
    :members:
 
+.. _dmsp_ssusi:
+
+DMSP SSUSI
+----------
+
+.. automodule:: pysatNASA.instruments.dmsp_ssusi
+   :members:
+
 .. _formosat1_ivm:
 
 FORMOSAT-1 IVM

--- a/pysatNASA/instruments/__init__.py
+++ b/pysatNASA/instruments/__init__.py
@@ -4,10 +4,11 @@
 Each instrument is contained within a subpackage of this set.
 
 """
+from pysatNASA.instruments import methods  # noqa F401
 
 __all__ = ['cnofs_ivm', 'cnofs_plp', 'cnofs_vefi',
            'de2_lang', 'de2_nacs', 'de2_rpa', 'de2_wats',
-           'formosat1_ivm',
+           'dmsp_ssusi', 'formosat1_ivm',
            'icon_euv', 'icon_fuv', 'icon_ivm', 'icon_mighti',
            'iss_fpmu', 'jpl_gps', 'omni_hro', 'ses14_gold',
            'timed_saber', 'timed_see']

--- a/pysatNASA/instruments/dmsp_ssusi.py
+++ b/pysatNASA/instruments/dmsp_ssusi.py
@@ -133,7 +133,7 @@ def load(fnames, tag='', inst_id=''):
     ::
 
         inst = pysat.Instrument('dmsp', 'ssusi', tag='edr-aurora',
-                                inst_id='f16')
+                                inst_id='f15')
         inst.load(2006, 1)
 
     """

--- a/pysatNASA/instruments/dmsp_ssusi.py
+++ b/pysatNASA/instruments/dmsp_ssusi.py
@@ -133,7 +133,7 @@ def load(fnames, tag='', inst_id=''):
     ::
 
         inst = pysat.Instrument('dmsp', 'ssusi', tag='edr-aurora',
-                                inst_id='f15')
+                                inst_id='f16')
         inst.load(2006, 1)
 
     """

--- a/pysatNASA/instruments/dmsp_ssusi.py
+++ b/pysatNASA/instruments/dmsp_ssusi.py
@@ -58,8 +58,8 @@ from pysat.instruments.methods import general as mm_gen
 from pysat.utils.io import load_netcdf
 
 from pysatNASA.instruments.methods import cdaweb as cdw
-from pysatNASA.instruments.methods import general as mm_nasa
 from pysatNASA.instruments.methods import dmsp as mm_dmsp
+from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatNASA/instruments/dmsp_ssusi.py
+++ b/pysatNASA/instruments/dmsp_ssusi.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+"""Module for the DMSP SSUSI instrument.
+
+Supports the Special Sensor Ultraviolet Spectrographic Imager (SSUSI)
+instrument on Defense Meteorological Satellite Program (DMSP).
+
+From JHU APL:
+
+SSUSI was designed for the DMSP Block 5D-3 satellites. These satellites are
+placed into nearly polar, sun-synchronous orbits at an altitude of about 850 km.
+SSUSI is a remote-sensing instrument which measures ultraviolet (UV) emissions
+in five different wavelength bands from the Earth's upper atmosphere. SSUSI is
+mounted on a nadir-looking panel of the satellite. The multicolor images from
+SSUSI cover the visible Earth disk from horizon to horizon and the anti-sunward
+limb up to an altitude of approximately 520 km.
+
+The UV images and the derived environmental data provide the Air Force Weather
+Agency (Offutt Air Force Base, Bellevue, NE) with near real-time information
+that can be utilized in a number of applications, such as maintenance of high
+frequency (HF) communication links and related systems and assessment of the
+environmental hazard to astronauts on the Space Station.
+
+References
+----------
+Larry J. Paxton, Daniel Morrison, Yongliang Zhang, Hyosub Kil, Brian Wolven,
+Bernard S. Ogorzalek, David C. Humm, and Ching-I. Meng "Validation of remote
+sensing products produced by the Special Sensor Ultraviolet Scanning Imager
+(SSUSI): a far UV-imaging spectrograph on DMSP F-16", Proc. SPIE 4485, Optical
+Spectroscopic Techniques, Remote Sensing, and Instrumentation for Atmospheric
+and Space Research IV, (30 January 2002); doi:10.1117/12.454268
+
+Properties
+----------
+platform
+    'dmsp'
+name
+    'ssusi'
+tag
+    'edr-aurora'
+inst_id
+    'f16', 'f17', 'f18', 'f19'
+
+
+Warnings
+--------
+- Currently no cleaning routine.
+
+
+"""
+
+import datetime as dt
+import functools
+import numpy as np
+import pandas as pds
+import xarray as xr
+
+from pysat.instruments.methods import general as mm_gen
+from pysat.utils.io import load_netcdf
+
+from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import general as mm_nasa
+from pysatNASA.instruments.methods import dmsp as mm_dmsp
+
+# ----------------------------------------------------------------------------
+# Instrument attributes
+
+platform = 'dmsp'
+name = 'ssusi'
+tags = {'edr-aurora': ''.join(['Electron energy flux and mean energy, auroral',
+                               ' boundaries, identified discrete auroral arcs,',
+                               ' hemispheric power, and magnetic field lines ',
+                               'traced to 4 Earth radii'])}
+inst_ids = {sat_id: list(tags.keys())
+            for sat_id in ['f16', 'f17', 'f18', 'f19']}
+
+pandas_format = False
+multi_file_day = True
+
+# ----------------------------------------------------------------------------
+# Instrument test attributes
+
+_test_dates = {inst_id: {tag: dt.datetime(2015, 1, 1) for tag in tags.keys()}
+               for inst_id in inst_ids.keys()}
+
+# ----------------------------------------------------------------------------
+# Instrument methods
+
+
+# Use standard init routine
+init = functools.partial(mm_nasa.init, module=mm_dmsp, name=name)
+
+# No cleaning, use standard warning function instead
+clean = mm_nasa.clean_warn
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+#
+# Use the default CDAWeb and pysat methods
+
+# Set the list_files routine
+fname = ''.join(['dmsp{inst_id:s}_ssusi_{tag:s}_{{year:04d}}{{day:03d}}T',
+                 '{{hour:02d}}{{minute:02d}}{{second:02d}}-???????T??????-REV',
+                 '?????_vA{{version:1d}}.?.?r{{cycle:03d}}.nc'])
+supported_tags = {sat_id: {tag: fname.format(tag=tag, inst_id=sat_id)
+                           for tag in tags.keys()}
+                  for sat_id in inst_ids.keys()}
+list_files = functools.partial(mm_gen.list_files,
+                               supported_tags=supported_tags)
+
+
+# Set the load routine
+def load(fnames, tag='', inst_id=''):
+    """Load DMSP SSUSI data and meta data.
+
+    Parameters
+    ----------
+    fnames : array-like
+        Iterable of filename strings, full path, to data files to be loaded.
+    tag : str
+        Tag name used to identify particular data set to be loaded (default='')
+    inst_id : str
+        DMSP satellite ID (default='')
+
+    Returns
+    -------
+    data : pds.DataFrame or xr.Dataset
+        Data to be assigned to the pysat.Instrument.data object.
+    mdata : pysat.Meta
+        Pysat Meta data for each data variable.
+
+    Examples
+    --------
+    ::
+
+        inst = pysat.Instrument('dmsp', 'ssusi', tag='edr-aurora',
+                                inst_id='f16')
+        inst.load(2006, 1)
+
+    """
+    # Define the input variables
+    labels = {'units': ('UNITS', str), 'desc': ('TITLE', str)}
+
+    # CDAWeb stores these files in the NetCDF format instead of the CDF format
+    single_data = list()
+    for fname in fnames:
+        # There are multiple files per day, with time as a variable rather
+        # than a dimension or coordinate.  Additionally, no coordinates
+        # are assigned.
+        subday_data, mdata = load_netcdf(fname, epoch_name='TIME',
+                                         epoch_unit='s', labels=labels,
+                                         pandas_format=pandas_format)
+        single_data.append(subday_data)
+
+    # After loading all the data, determine which dimensions need to be expanded
+    combo_dims = {dim: max([sdata.dims[dim] for sdata in single_data])
+                  for dim in subday_data.dims.keys()}
+
+    # Expand the data so that all dimensions are the same shape
+    for i, sdata in enumerate(single_data):
+        # Determine which dimensions need to be updated
+        fix_dims = [dim for dim in sdata.dims.keys()
+                    if sdata.dims[dim] < combo_dims[dim]]
+
+        new_data = {}
+        update_new = False
+        for dvar in sdata.data_vars.keys():
+            # See if any dimensions need to be updated
+            update_dims = list(set(sdata[dvar].dims) & set(fix_dims))
+
+            # Save the old data as is, or pad it to have the right dims
+            if len(update_dims) > 0:
+                update_new = True
+                new_shape = list(sdata[dvar].values.shape)
+                old_slice = [slice(0, ns) for ns in new_shape]
+
+                for dim in update_dims:
+                    idim = list(sdata[dvar].dims).index(dim)
+                    new_shape[idim] = combo_dims[dim]
+
+                # Set the new data for output
+                new_dat = np.full(shape=new_shape, fill_value=mdata[
+                    dvar, mdata.labels.fill_val])
+                new_dat[tuple(old_slice)] = sdata[dvar].values
+                new_data[dvar] = (sdata[dvar].dims, new_dat)
+            else:
+                new_data[dvar] = sdata[dvar]
+
+        # Calculate the time for this data file
+        ftime = dt.datetime.strptime(
+            "{:4d}-{:03d}".format(
+                sdata['YEAR'].values.astype(int),
+                sdata['DOY'].values.astype(int)), '%Y-%j') + (
+                    pds.to_datetime(sdata['time'].values).to_pydatetime()
+                    - dt.datetime(1970, 1, 1))
+
+        # Get the updated dataset
+        ndata = xr.Dataset(new_data) if update_new else sdata
+        ndata['time'] = ftime
+
+        # Assign a datetime variable, making indexing possible
+        single_data[i] = ndata.assign_coords(
+            {'time': ndata['time']}).expand_dims(dim='time')
+
+    # Combine all the data, indexing along time
+    data = xr.combine_by_coords(single_data)
+
+    # TODO(https://github.com/pysat/pysat/issues/1078): Update the metadata by
+    # removing 'TIME', once possible
+
+    return data, mdata
+
+
+# Set the download routine
+basic_tag = {'remote_dir': ''.join(('/pub/data/dmsp/dmsp{inst_id:s}/ssusi/',
+                                    '/data/{tag:s}/{{year:4d}}/{{day:03d}}/')),
+             'fname': fname}
+download_tags = {
+    sat_id: {tag: {btag: basic_tag[btag].format(tag=tag, inst_id=sat_id)
+                   for btag in basic_tag.keys()} for tag in tags.keys()}
+    for sat_id in inst_ids.keys()}
+download = functools.partial(cdw.download, supported_tags=download_tags)
+
+# Set the list_remote_files routine
+list_remote_files = functools.partial(cdw.list_remote_files,
+                                      supported_tags=download_tags)

--- a/pysatNASA/instruments/methods/__init__.py
+++ b/pysatNASA/instruments/methods/__init__.py
@@ -4,6 +4,7 @@ from pysatNASA.instruments.methods._cdf import CDF  # noqa F401
 from pysatNASA.instruments.methods import cdaweb  # noqa F401
 from pysatNASA.instruments.methods import cnofs  # noqa F401
 from pysatNASA.instruments.methods import de2  # noqa F401
+from pysatNASA.instruments.methods import dmsp  # noqa F401
 from pysatNASA.instruments.methods import general  # noqa F401
 from pysatNASA.instruments.methods import icon  # noqa F401
 from pysatNASA.instruments.methods import omni  # noqa F401

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -398,7 +398,7 @@ def load_xarray(fnames, tag='', inst_id='',
 
 def download(date_array, tag='', inst_id='', supported_tags=None,
              remote_url='https://cdaweb.gsfc.nasa.gov', data_path=None):
-    """Download NASA CDAWeb CDF data.
+    """Download NASA CDAWeb data.
 
     This routine is intended to be used by pysat instrument modules supporting
     a particular NASA CDAWeb dataset.
@@ -427,7 +427,7 @@ def download(date_array, tag='', inst_id='', supported_tags=None,
     --------
     ::
 
-        # download support added to cnofs_vefi.py using code below
+        # Download support added to cnofs_vefi.py using code below
         fn = 'cnofs_vefi_bfield_1sec_{year:4d}{month:02d}{day:02d}_v05.cdf'
         dc_b_tag = {'remote_dir': ''.join(('/pub/data/cnofs/vefi/bfield_1sec',
                                             '/{year:4d}/')),
@@ -599,18 +599,27 @@ def list_remote_files(tag='', inst_id='', start=None, stop=None,
         stop = dt.datetime.now() if (stop is None) else stop
 
         if 'year' in search_dir['keys']:
+            url_list = []
             if 'month' in search_dir['keys']:
                 search_times = pds.date_range(start,
                                               stop + pds.DateOffset(months=1),
                                               freq='M')
+                for time in search_times:
+                    subdir = format_dir.format(year=time.year, month=time.month)
+                    url_list.append('/'.join((remote_url, subdir)))
             else:
-                search_times = pds.date_range(start,
-                                              stop + pds.DateOffset(years=1),
-                                              freq='Y')
-            url_list = []
-            for time in search_times:
-                subdir = format_dir.format(year=time.year, month=time.month)
-                url_list.append('/'.join((remote_url, subdir)))
+                if 'day' in search_dir['keys']:
+                    search_times = pds.date_range(start, stop
+                                                  + pds.DateOffset(days=1),
+                                                  freq='D')
+                else:
+                    search_times = pds.date_range(start, stop
+                                                  + pds.DateOffset(years=1),
+                                                  freq='Y')
+                for time in search_times:
+                    doy = int(time.strftime('%j'))
+                    subdir = format_dir.format(year=time.year, day=doy)
+                    url_list.append('/'.join((remote_url, subdir)))
     try:
         for top_url in url_list:
             for level in range(n_layers + 1):

--- a/pysatNASA/instruments/methods/dmsp.py
+++ b/pysatNASA/instruments/methods/dmsp.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Provides non-instrument specific routines for the DMSP data."""
+
+ackn_str = "".join(["This Defense Meteorological Satellite Program (DMSP) ",
+                    "satellite data is provided through CDAWeb"])
+
+refs = {'ssusi': ' '.join(('Larry J. Paxton, Daniel Morrison, Yongliang Zhang,',
+                           ' Hyosub Kil, Brian Wolven, Bernard S. Ogorzalek, ',
+                           'David C. Humm, and Ching-I. Meng "Validation of ',
+                           'remote sensing products produced by the Special ',
+                           'Sensor Ultraviolet Scanning Imager (SSUSI): a far ',
+                           'UV-imaging spectrograph on DMSP F-16", Proc. SPIE ',
+                           '4485, Optical Spectroscopic Techniques, Remote ',
+                           'Sensing, and Instrumentation for Atmospheric and ',
+                           'Space Research IV, (30 January 2002); ',
+                           'doi:10.1117/12.454268'))}

--- a/pysatNASA/instruments/methods/dmsp.py
+++ b/pysatNASA/instruments/methods/dmsp.py
@@ -4,13 +4,13 @@
 ackn_str = "".join(["This Defense Meteorological Satellite Program (DMSP) ",
                     "satellite data is provided through CDAWeb"])
 
-refs = {'ssusi': ' '.join(('Larry J. Paxton, Daniel Morrison, Yongliang Zhang,',
-                           ' Hyosub Kil, Brian Wolven, Bernard S. Ogorzalek, ',
-                           'David C. Humm, and Ching-I. Meng "Validation of ',
-                           'remote sensing products produced by the Special ',
-                           'Sensor Ultraviolet Scanning Imager (SSUSI): a far ',
-                           'UV-imaging spectrograph on DMSP F-16", Proc. SPIE ',
-                           '4485, Optical Spectroscopic Techniques, Remote ',
-                           'Sensing, and Instrumentation for Atmospheric and ',
-                           'Space Research IV, (30 January 2002); ',
-                           'doi:10.1117/12.454268'))}
+refs = {'ssusi': ''.join(('Larry J. Paxton, Daniel Morrison, Yongliang Zhang,',
+                          ' Hyosub Kil, Brian Wolven, Bernard S. Ogorzalek, ',
+                          'David C. Humm, and Ching-I. Meng "Validation of ',
+                          'remote sensing products produced by the Special ',
+                          'Sensor Ultraviolet Scanning Imager (SSUSI): a far ',
+                          'UV-imaging spectrograph on DMSP F-16", Proc. SPIE ',
+                          '4485, Optical Spectroscopic Techniques, Remote ',
+                          'Sensing, and Instrumentation for Atmospheric and ',
+                          'Space Research IV, (30 January 2002); ',
+                          'doi:10.1117/12.454268'))}

--- a/pysatNASA/tests/test_methods_dmsp.py
+++ b/pysatNASA/tests/test_methods_dmsp.py
@@ -1,0 +1,31 @@
+"""Unit tests for the DMSP methods."""
+
+from pysatNASA.instruments.methods import dmsp
+
+
+class TestDMSPMethods(object):
+    """Unit tests for `pysat.instruments.methods.dmsp`."""
+
+    def setup_method(self):
+        """Set up the unit test environment for each method."""
+        self.names = ['ssusi']
+        return
+
+    def teardown_method(self):
+        """Clean up the unit test environment after each method."""
+
+        del self.names
+        return
+
+    def test_ack(self):
+        """Test that the acknowledgements reference the correct platform."""
+
+        assert dmsp.find('Defense Meteorological Satellite Program') >= 0
+        return
+
+    def test_ref(self):
+        """Test that all DMSP instruments have references."""
+
+        for name in self.names:
+            assert name in dmsp.refs.keys(), "No reference for {:}".format(name)
+        return

--- a/pysatNASA/tests/test_methods_dmsp.py
+++ b/pysatNASA/tests/test_methods_dmsp.py
@@ -20,7 +20,8 @@ class TestDMSPMethods(object):
     def test_ack(self):
         """Test that the acknowledgements reference the correct platform."""
 
-        assert dmsp.find('Defense Meteorological Satellite Program') >= 0
+        assert dmsp.ackn_str.find(
+            'Defense Meteorological Satellite Program') >= 0
         return
 
     def test_ref(self):


### PR DESCRIPTION
# Description

Added a new instrument for the DMSP SSUSI EDR-Aurora data.  While adding this instrument support, discovered a bug in the general CDAWeb functions.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

```
import datetime as dt
import matplotlib.pyplot as plt
import pysat
import pysatNASA

# Initalize the instrument, download and load the data.  Loading will bring up logger warnings from the pysat function
# that aren't important in this instance
ssusi = pysat.Instrument(inst_module=pysatNASA.instruments.dmsp_ssusi, tag='edr-aurora', inst_id='f17')
ssusi.download(start=dt.datetime(2015, 1, 1))
ssusi.load(date=dt.datetime(2015, 1, 1))

# Create a plot like the one shown here
fig = plt.figure()
axs = fig.add_subplot(212, projection='polar')
axn = fig.add_subplot(211, projection='polar')
dvar = 'SOUTH_POLAR_GEOGRAPHIC_LONGITUDE'
lvar = 'SOUTH_POLAR_GEOGRAPHIC_LATITUDE'
ndvar = 'NORTH_POLAR_GEOGRAPHIC_LONGITUDE'
nlvar = 'NORTH_POLAR_GEOGRAPHIC_LATITUDE'

# Replace colors and markers with a list of colors and markers
for i, dtime in enumerate(ssusi.index):
    axs.plot(np.radians(ssusi[dvar][i]), 90 + ssusi[lvar][i], '.', label='{:}'.format(dtime), color='k')
    axn.plot(np.radians(ssusi[ndvar][i]), 90 - ssusi[nlvar][i], '.', color='k')

# Do various formatting to make things look nice
```
![dmsp_ssusi_ocb](https://user-images.githubusercontent.com/7045886/221303492-63e18462-a627-44a5-b137-eb3d16112996.png)

## Test Configuration
* Operating system: OS X Big Sur
* Version number: Python 3.8
* Any details about your local setup that are relevant: develop branch of pysat

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
