### PR TITLE
STY: docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated CDAWeb routines to allow for data stored by year/day-of-year
 * Maintenance
   * Added a version cap for numpy (required for cdf interface, revisit before release)
+  * Updated dosctring style for consistency
 
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class

--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -29,6 +29,14 @@ inst_id
     None supported
 
 
+Warnings
+--------
+- The sampling rate of the instrument changes on July 29th, 2010.
+  The rate is attached to the instrument object as .sample_rate.
+
+- The cleaning parameters for the instrument are still under development.
+
+
 References
 ----------
 A brief discussion of the C/NOFS mission and instruments can be found at
@@ -45,14 +53,6 @@ Discussion of cleaning parameters for ion temperature can be found in:
 Hairston, M. R., W. R. Coley, and R. A. Heelis (2010), Mapping the
 duskside topside ionosphere with CINDI and DMSP, J. Geophys. Res.,115,
 A08324, doi:10.1029/2009JA015051.
-
-
-Warnings
---------
-- The sampling rate of the instrument changes on July 29th, 2010.
-  The rate is attached to the instrument object as .sample_rate.
-
-- The cleaning parameters for the instrument are still under development.
 
 """
 

--- a/pysatNASA/instruments/cnofs_ivm.py
+++ b/pysatNASA/instruments/cnofs_ivm.py
@@ -16,6 +16,19 @@ The DM directly measures the arrival angle of plasma. Using the reported
 motion of the satellite the angle is converted into ion motion along
 two orthogonal directions, perpendicular to the satellite track.
 
+
+Properties
+----------
+platform
+    'cnofs'
+name
+    'ivm'
+tag
+    None supported
+inst_id
+    None supported
+
+
 References
 ----------
 A brief discussion of the C/NOFS mission and instruments can be found at
@@ -33,17 +46,6 @@ Hairston, M. R., W. R. Coley, and R. A. Heelis (2010), Mapping the
 duskside topside ionosphere with CINDI and DMSP, J. Geophys. Res.,115,
 A08324, doi:10.1029/2009JA015051.
 
-
-Properties
-----------
-platform
-    'cnofs'
-name
-    'ivm'
-tag
-    None supported
-inst_id
-    None supported
 
 Warnings
 --------

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -29,12 +29,6 @@ Probe.
 
 The data is PRELIMINARY, and as such, is intended for BROWSE PURPOSES ONLY.
 
-References
-----------
-A brief discussion of the C/NOFS mission and instruments can be found at
-de La Beaujardière, O., et al. (2004), C/NOFS: A mission to forecast
-scintillations, J. Atmos. Sol. Terr. Phys., 66, 1573–1591,
-doi:10.1016/j.jastp.2004.07.030.
 
 Properties
 ----------
@@ -46,6 +40,14 @@ tag
     None supported
 inst_id
     None supported
+
+
+References
+----------
+A brief discussion of the C/NOFS mission and instruments can be found at
+de La Beaujardière, O., et al. (2004), C/NOFS: A mission to forecast
+scintillations, J. Atmos. Sol. Terr. Phys., 66, 1573–1591,
+doi:10.1016/j.jastp.2004.07.030.
 
 
 Warnings

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -42,19 +42,19 @@ inst_id
     None supported
 
 
+Warnings
+--------
+- The data are PRELIMINARY, and as such, are intended for BROWSE PURPOSES ONLY.
+- Currently no cleaning routine.
+- Module not written by PLP team.
+
+
 References
 ----------
 A brief discussion of the C/NOFS mission and instruments can be found at
 de La Beaujardière, O., et al. (2004), C/NOFS: A mission to forecast
 scintillations, J. Atmos. Sol. Terr. Phys., 66, 1573–1591,
 doi:10.1016/j.jastp.2004.07.030.
-
-
-Warnings
---------
-- The data are PRELIMINARY, and as such, are intended for BROWSE PURPOSES ONLY.
-- Currently no cleaning routine.
-- Module not written by PLP team.
 
 """
 

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -26,12 +26,6 @@ B_west    Magnetic field in the west direction
 
 The data is PRELIMINARY, and as such, is intended for BROWSE PURPOSES ONLY.
 
-References
-----------
-A brief discussion of the C/NOFS mission and instruments can be found at
-de La Beaujardière, O., et al. (2004), C/NOFS: A mission to forecast
-scintillations, J. Atmos. Sol. Terr. Phys., 66, 1573–1591,
-doi:10.1016/j.jastp.2004.07.030.
 
 Properties
 ----------
@@ -43,6 +37,14 @@ tag
     Select measurement type, one of {'dc_b'}
 inst_id
     None supported
+
+
+References
+----------
+A brief discussion of the C/NOFS mission and instruments can be found at
+de La Beaujardière, O., et al. (2004), C/NOFS: A mission to forecast
+scintillations, J. Atmos. Sol. Terr. Phys., 66, 1573–1591,
+doi:10.1016/j.jastp.2004.07.030.
 
 
 Note

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -39,14 +39,6 @@ inst_id
     None supported
 
 
-References
-----------
-A brief discussion of the C/NOFS mission and instruments can be found at
-de La Beaujardière, O., et al. (2004), C/NOFS: A mission to forecast
-scintillations, J. Atmos. Sol. Terr. Phys., 66, 1573–1591,
-doi:10.1016/j.jastp.2004.07.030.
-
-
 Note
 ----
 - tag = 'dc_b': 1 second DC magnetometer data
@@ -57,6 +49,14 @@ Warnings
 - The data is PRELIMINARY, and as such, is intended for BROWSE PURPOSES ONLY.
 - Limited cleaning routine.
 - Module not written by VEFI team.
+
+
+References
+----------
+A brief discussion of the C/NOFS mission and instruments can be found at
+de La Beaujardière, O., et al. (2004), C/NOFS: A mission to forecast
+scintillations, J. Atmos. Sol. Terr. Phys., 66, 1573–1591,
+doi:10.1016/j.jastp.2004.07.030.
 
 """
 

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -37,17 +37,16 @@ tag
     None Supported
 
 
+Warnings
+--------
+- Currently no cleaning routine.
+
+
 References
 ----------
 J. P. Krehbiel, L. H. Brace, R. F. Theis, W. H. Pinkus, and R. B. Kaplan,
 "The Dynamics Explorer 2 Langmuir Probe (LANG)", Space Sci. Instrum., 5,
 493-502, 1981.
-
-
-Warnings
---------
-- Currently no cleaning routine.
-
 
 """
 

--- a/pysatNASA/instruments/de2_lang.py
+++ b/pysatNASA/instruments/de2_lang.py
@@ -25,12 +25,6 @@ data rate sampling of selected V-I curves for transmission to ground to verify
 or correct the inflight processed data. Time resolution was 0.5 seconds.
 
 
-References
-----------
-J. P. Krehbiel, L. H. Brace, R. F. Theis, W. H. Pinkus, and R. B. Kaplan,
-"The Dynamics Explorer 2 Langmuir Probe (LANG)", Space Sci. Instrum., 5,
-493-502, 1981.
-
 Properties
 ----------
 platform
@@ -41,6 +35,13 @@ inst_id
     None Supported
 tag
     None Supported
+
+
+References
+----------
+J. P. Krehbiel, L. H. Brace, R. F. Theis, W. H. Pinkus, and R. B. Kaplan,
+"The Dynamics Explorer 2 Langmuir Probe (LANG)", Space Sci. Instrum., 5,
+493-502, 1981.
 
 
 Warnings

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -62,16 +62,16 @@ tag
     None Supported
 
 
+Warnings
+--------
+- Currently no cleaning routine.
+
+
 References
 ----------
 G. R. Carrignan, B. P. Block, J. C. Maurer,  A. E. Hedin, C. A. Reber,
 N. W. Spencer, "The neutral mass spectrometer on Dynamics Explorer B",
 Space Sci. Instrum., 5, 429-441, 1981.
-
-
-Warnings
---------
-- Currently no cleaning routine.
 
 """
 

--- a/pysatNASA/instruments/de2_nacs.py
+++ b/pysatNASA/instruments/de2_nacs.py
@@ -50,12 +50,6 @@ between minimum (background) and maximum count rate for atomic nitrogen
 were lost between 12 March 1982 and 31 March 1982 when the counter overflowed.
 
 
-References
-----------
-G. R. Carrignan, B. P. Block, J. C. Maurer,  A. E. Hedin, C. A. Reber,
-N. W. Spencer, "The neutral mass spectrometer on Dynamics Explorer B",
-Space Sci. Instrum., 5, 429-441, 1981.
-
 Properties
 ----------
 platform
@@ -66,6 +60,14 @@ inst_id
     None Supported
 tag
     None Supported
+
+
+References
+----------
+G. R. Carrignan, B. P. Block, J. C. Maurer,  A. E. Hedin, C. A. Reber,
+N. W. Spencer, "The neutral mass spectrometer on Dynamics Explorer B",
+Space Sci. Instrum., 5, 429-441, 1981.
+
 
 Warnings
 --------

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -49,16 +49,16 @@ tag
     None Supported
 
 
+Warnings
+--------
+- Currently no cleaning routine.
+
+
 References
 ----------
 W. B. Hanson, R. A. Heelis, R. A. Power, C. R. Lippincott, D. R. Zuccaro,
 B. J. Holt, L. H. Harmon, and S. Sanatani, “The retarding potential analyzer
 for dynamics explorer-B,” Space Sci. Instrum. 5, 503–510 (1981).
-
-
-Warnings
---------
-- Currently no cleaning routine.
 
 """
 

--- a/pysatNASA/instruments/de2_rpa.py
+++ b/pysatNASA/instruments/de2_rpa.py
@@ -36,11 +36,6 @@ to 82057 13:16:00 UT. This data set is based on the revised version of the RPA
 files that was submitted by the PI team in June of 1995. The revised RPA data
 include a correction to the spacecraft potential.
 
-References
-----------
-W. B. Hanson, R. A. Heelis, R. A. Power, C. R. Lippincott, D. R. Zuccaro,
-B. J. Holt, L. H. Harmon, and S. Sanatani, “The retarding potential analyzer
-for dynamics explorer-B,” Space Sci. Instrum. 5, 503–510 (1981).
 
 Properties
 ----------
@@ -52,6 +47,14 @@ inst_id
     None Supported
 tag
     None Supported
+
+
+References
+----------
+W. B. Hanson, R. A. Heelis, R. A. Power, C. R. Lippincott, D. R. Zuccaro,
+B. J. Holt, L. H. Harmon, and S. Sanatani, “The retarding potential analyzer
+for dynamics explorer-B,” Space Sci. Instrum. 5, 503–510 (1981).
+
 
 Warnings
 --------

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -59,16 +59,16 @@ tag
     None Supported
 
 
+Warnings
+--------
+- Currently no cleaning routine.
+
+
 References
 ----------
 N. W. Spencer, L. E. Wharton, H. B. Niemann, A. E. Hedin, G. R. Carrignan,
 J. C. Maurer, "The Dynamics Explorer Wind and Temperature Spectrometer",
 Space Sci. Instrum., 5, 417-428, 1981.
-
-
-Warnings
---------
-- Currently no cleaning routine.
 
 """
 

--- a/pysatNASA/instruments/de2_wats.py
+++ b/pysatNASA/instruments/de2_wats.py
@@ -47,12 +47,6 @@ WATS_VOLDESC_SFDU_DE.DOC and WATS_FORMAT_SFDU_DE.DOC files. More information
 about the processing done at NSSDC is given in WATS_NSSDC_PRO_DE.DOC.
 
 
-References
-----------
-N. W. Spencer, L. E. Wharton, H. B. Niemann, A. E. Hedin, G. R. Carrignan,
-J. C. Maurer, "The Dynamics Explorer Wind and Temperature Spectrometer",
-Space Sci. Instrum., 5, 417-428, 1981.
-
 Properties
 ----------
 platform
@@ -63,6 +57,14 @@ inst_id
     None Supported
 tag
     None Supported
+
+
+References
+----------
+N. W. Spencer, L. E. Wharton, H. B. Niemann, A. E. Hedin, G. R. Carrignan,
+J. C. Maurer, "The Dynamics Explorer Wind and Temperature Spectrometer",
+Space Sci. Instrum., 5, 417-428, 1981.
+
 
 Warnings
 --------

--- a/pysatNASA/instruments/dmsp_ssusi.py
+++ b/pysatNASA/instruments/dmsp_ssusi.py
@@ -20,14 +20,6 @@ that can be utilized in a number of applications, such as maintenance of high
 frequency (HF) communication links and related systems and assessment of the
 environmental hazard to astronauts on the Space Station.
 
-References
-----------
-Larry J. Paxton, Daniel Morrison, Yongliang Zhang, Hyosub Kil, Brian Wolven,
-Bernard S. Ogorzalek, David C. Humm, and Ching-I. Meng "Validation of remote
-sensing products produced by the Special Sensor Ultraviolet Scanning Imager
-(SSUSI): a far UV-imaging spectrograph on DMSP F-16", Proc. SPIE 4485, Optical
-Spectroscopic Techniques, Remote Sensing, and Instrumentation for Atmospheric
-and Space Research IV, (30 January 2002); doi:10.1117/12.454268
 
 Properties
 ----------
@@ -39,6 +31,16 @@ tag
     'edr-aurora'
 inst_id
     'f16', 'f17', 'f18', 'f19'
+
+
+References
+----------
+Larry J. Paxton, Daniel Morrison, Yongliang Zhang, Hyosub Kil, Brian Wolven,
+Bernard S. Ogorzalek, David C. Humm, and Ching-I. Meng "Validation of remote
+sensing products produced by the Special Sensor Ultraviolet Scanning Imager
+(SSUSI): a far UV-imaging spectrograph on DMSP F-16", Proc. SPIE 4485, Optical
+Spectroscopic Techniques, Remote Sensing, and Instrumentation for Atmospheric
+and Space Research IV, (30 January 2002); doi:10.1117/12.454268
 
 
 Warnings

--- a/pysatNASA/instruments/dmsp_ssusi.py
+++ b/pysatNASA/instruments/dmsp_ssusi.py
@@ -33,6 +33,11 @@ inst_id
     'f16', 'f17', 'f18', 'f19'
 
 
+Warnings
+--------
+- Currently no cleaning routine.
+
+
 References
 ----------
 Larry J. Paxton, Daniel Morrison, Yongliang Zhang, Hyosub Kil, Brian Wolven,
@@ -41,12 +46,6 @@ sensing products produced by the Special Sensor Ultraviolet Scanning Imager
 (SSUSI): a far UV-imaging spectrograph on DMSP F-16", Proc. SPIE 4485, Optical
 Spectroscopic Techniques, Remote Sensing, and Instrumentation for Atmospheric
 and Space Research IV, (30 January 2002); doi:10.1117/12.454268
-
-
-Warnings
---------
-- Currently no cleaning routine.
-
 
 """
 

--- a/pysatNASA/instruments/formosat1_ivm.py
+++ b/pysatNASA/instruments/formosat1_ivm.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Module for the ICON EUV instrument.
+"""Module for the Formosat-1 IVM instrument.
 
 Supports the Ion Velocity Meter (IVM) onboard the Formosat-1 (formerly
 ROCSAT-1) mission. Downloads data from the NASA Coordinated Data Analysis

--- a/pysatNASA/instruments/jpl_gps.py
+++ b/pysatNASA/instruments/jpl_gps.py
@@ -29,6 +29,11 @@ inst_id
     None supported
 
 
+Warnings
+--------
+- The cleaning parameters for the instrument are still under development.
+
+
 References
 ----------
 Pi, X., A. J. Mannucci, U. J. Lindqwister, and C. M. Ho, Monitoring of global
@@ -38,11 +43,6 @@ Lett., 24, 2283, 1997.
 Pi, X., F. J. Meyer, K. Chotoo, Anthony Freeman, R. G. Caton, and C. T.
 Bridgwood, Impact of ionospheric scintillation on Spaceborne SAR observations
 studied using GNSS, Proc. ION-GNSS, pp.1998-2006, 2012.
-
-
-Warnings
---------
-- The cleaning parameters for the instrument are still under development.
 
 """
 

--- a/pysatNASA/instruments/jpl_gps.py
+++ b/pysatNASA/instruments/jpl_gps.py
@@ -16,16 +16,6 @@ GNSS data contributing to the ROTI computation are primarily collected from
 the global network of International GNSS Service and the regional network of
 Continuous Operating Reference Station (CORS).
 
-References
-----------
-Pi, X., A. J. Mannucci, U. J. Lindqwister, and C. M. Ho, Monitoring of global
-ionospheric irregularities using the worldwide GPS network, Geophys. Res.
-Lett., 24, 2283, 1997.
-
-Pi, X., F. J. Meyer, K. Chotoo, Anthony Freeman, R. G. Caton, and C. T.
-Bridgwood, Impact of ionospheric scintillation on Spaceborne SAR observations
-studied using GNSS, Proc. ION-GNSS, pp.1998-2006, 2012.
-
 
 Properties
 ----------
@@ -37,6 +27,18 @@ tag
     ['roti']
 inst_id
     None supported
+
+
+References
+----------
+Pi, X., A. J. Mannucci, U. J. Lindqwister, and C. M. Ho, Monitoring of global
+ionospheric irregularities using the worldwide GPS network, Geophys. Res.
+Lett., 24, 2283, 1997.
+
+Pi, X., F. J. Meyer, K. Chotoo, Anthony Freeman, R. G. Caton, and C. T.
+Bridgwood, Impact of ionospheric scintillation on Spaceborne SAR observations
+studied using GNSS, Proc. ION-GNSS, pp.1998-2006, 2012.
+
 
 Warnings
 --------


### PR DESCRIPTION
# Description

Addresses #149

Moves `properties` to be the first item under each module docstring.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Inspection.

## Test Configuration
* Operating system: Mac OS X Monterrey
* Version number: Python 3.10.8

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
