### PR TITLE
MAINT: remove version cap for xarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Maintenance
   * Added a version cap for numpy (required for cdf interface, revisit before release)
   * Updated dosctring style for consistency
+  * Removed version cap for xarray
 
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Python 3.8+.
 | numpy            |                   |
 | pandas           |                   |
 | requests         |                   |
-| xarray<2022.11   |                   |
+| xarray           |                   |
 
 ## GitHub Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ cdflib>=0.4.4
 numpy<1.24
 pandas
 pysat>=3.0.4
-xarray<2022.11
+xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests
 beautifulsoup4
 lxml
 cdflib>=0.4.4
-numpy<1.24
+numpy
 pandas
 pysat>=3.0.4
 xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests
 beautifulsoup4
 lxml
 cdflib>=0.4.4
-numpy
+numpy<1.24
 pandas
 pysat>=3.0.4
 xarray


### PR DESCRIPTION
# Description

Addresses #133

Removes the version cap for xarray.  RuntimeError bugs from 2022.11 have been removed in later versions.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Via github actions.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
