### PR TITLE
BUG/TST: update test behavior in the absence/presence of pysatCDF

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         numpy_ver: ["latest"]
         include:
           - python-version: "3.8"
-            numpy_ver: "1.20"
+            numpy_ver: "1.21"
             os: "ubuntu-latest"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,11 @@ jobs:
       if: ${{ matrix.numpy_ver != 'latest'}}
       run: |
         pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
+        pip install pysatCDF --no-binary=pysatCDF
 
     - name: Install standard dependencies
       run: |
         pip install -r requirements.txt
-        pip install pysatCDF --no-binary=pysatCDF
         pip install -r test_requirements.txt
 
     - name: Set up pysat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added unit tests for the different platform method attributes
   * xarray support for TIMED SEE
 * Maintenance
-  * Added a version cap for numpy (required for cdf interface, revisit before
-    release)
-  * Updated actions and templates based on pysatEcosystem docs.
+  * Removed duplicate tests if pysatCDF not isntalled
+  * Only test pysatCDF on GitHub Actions for older numpy versions
+  * Updated actions and templates based on pysatEcosystem docs
   * Remove pandas cap on NEP29 tests
   * Updated dosctring style for consistency
   * Removed version cap for xarray

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ For data products stored as CDF files, this package can use either `cdflib` or
 `pysatCDF`.  Note that `cdflib` is a pure python package and more readily
 deployable across systems, whereas `pysatCDF` interfaces with the fortran.  
 This is a faster approach for loading data, but may not install on all systems.  
-Therefore, `pysatCDF` is optional rather than required.
+There are known issues with `numpy`>=1.24. Therefore, `pysatCDF` is optional
+rather than required.  
 
 You can specify which load routine to use via the optional `use_cdflib` kwarg.
 If no kwarg is specified, `pysatNASA` will default to `pysatCDF` if it is

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -124,8 +124,10 @@ def load(fnames, tag='', inst_id='', file_cadence=dt.timedelta(days=1),
 
     Note
     ----
-    This routine is intended to be used by pysat instrument modules supporting
-    a particular NASA CDAWeb dataset
+    - This routine is intended to be used by pysat instrument modules supporting
+      a particular NASA CDAWeb dataset
+    - pysatCDF (as of v0.3.2) does not support numpy>=1.24.  Load errors may
+      arise.  See https://github.com/pysat/pysatCDF/issues/46
 
     """
 

--- a/pysatNASA/tests/test_instruments.py
+++ b/pysatNASA/tests/test_instruments.py
@@ -51,7 +51,9 @@ class TestInstruments(clslib.InstLibTests):
 
     @pytest.mark.second
     @pytest.mark.parametrize("inst_dict", instruments['cdf'])
-    @pytest.mark.skipif(cdflib_only)
+    @pytest.mark.skipif(cdflib_only,
+                        reason=" ".join(("Additional load tests not required",
+                                         "when pysatCDF not installed")))
     def test_load_cdflib(self, inst_dict):
         """Test that instruments load at each cleaning level.
 

--- a/pysatNASA/tests/test_instruments.py
+++ b/pysatNASA/tests/test_instruments.py
@@ -51,7 +51,7 @@ class TestInstruments(clslib.InstLibTests):
 
     @pytest.mark.second
     @pytest.mark.parametrize("inst_dict", instruments['cdf'])
-    @pytest.skipif(cdflib_only)
+    @pytest.mark.skipif(cdflib_only)
     def test_load_cdflib(self, inst_dict):
         """Test that instruments load at each cleaning level.
 

--- a/pysatNASA/tests/test_instruments.py
+++ b/pysatNASA/tests/test_instruments.py
@@ -16,6 +16,15 @@ import pysatNASA
 # Import the test classes from pysat
 from pysat.tests.classes import cls_instrument_library as clslib
 
+try:
+    import pysatCDF  # noqa: F401
+    # If this successfully imports, tests need to be run with both pysatCDF
+    # and cdflib
+    cdflib_only = False
+except ImportError:
+    # pysatCDF is not present, standard tests default to cdflib.
+    cdflib_only = True
+
 
 # Tell the standard tests which instruments to run each test on.
 # Need to return instrument list for custom tests.
@@ -42,6 +51,7 @@ class TestInstruments(clslib.InstLibTests):
 
     @pytest.mark.second
     @pytest.mark.parametrize("inst_dict", instruments['cdf'])
+    @pytest.skipif(cdflib_only)
     def test_load_cdflib(self, inst_dict):
         """Test that instruments load at each cleaning level.
 

--- a/pysatNASA/tests/test_instruments.py
+++ b/pysatNASA/tests/test_instruments.py
@@ -36,7 +36,9 @@ instruments['cdf'] = []
 for inst in instruments['download']:
     fname = inst['inst_module'].supported_tags[inst['inst_id']][inst['tag']]
     if '.cdf' in fname:
-        instruments['cdf'].append(inst)
+        temp_inst, _ = clslib.initialize_test_inst_and_date(inst)
+        if temp_inst.pandas_format:
+            instruments['cdf'].append(inst)
 
 
 class TestInstruments(clslib.InstLibTests):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests
 beautifulsoup4
 lxml
 cdflib>=0.4.4
-numpy<1.24
+numpy
 pandas
 pysat>=3.0.4
 cdasws


### PR DESCRIPTION
# Description

Addresses #142 

pysatCDF has known issues with numpy>= 1.24 (see https://github.com/pysat/pysatCDF/issues/46).  Since this is an optional install, the test behavior here is altered so that a package-wide version cap for numpy is not required.
- Updates GA tests to only use `pysatCDF` install for NEP29 tests (currently set to numpy 1.21)
- Includes logic in test_instruments so that additional load tests with `cdflib` are only run when `pysatCDF` is correctly installed. (The default behavior of the load routines is to use `pysatCDF` if possible, then fall back to `cdflib`, unless specified by the `use_cdflib` kwarg)
- Removes the additional tests for xarray instruments, which are only supported by `cdflib`.

NOTE: this is required before #155 can be tested.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Running Lines 1-41 of test_instruments.py to inspect whether instruments['cdf'] is correctly generate (ie, ACE and TIMED/SEE instrument not included since these are xarray).

Running pytest with pysatCDF installed and not installed to verify that skipif tests are working correctly.

## Test Configuration
* Operating system: Monterrey
* Version number: python 3.10.8

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
