### PR TITLE
BUG: data uniqueness for GOLD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Bug Fixes
   * Updated CDAWeb routines to allow for data stored by year/day-of-year
   * Updated GOLD nmax to sort scans by time.
+  * Added 1 usec to GOLD nmax channel B times to ensure uniqueness
 * Documentation
   * Added TIMED-GUVI platform
   * Added missing sub-module imports

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -14,9 +14,13 @@ tag
 
 Warnings
 --------
-- The cleaning parameters for the instrument are still under development.
-- strict_time_flag must be set to False
+The cleaning parameters for the instrument are still under development.
 
+Note
+----
+In roughly 0.3% of daily files, Channel A and Channel B scans begin at the same
+time.  One microsecond is added to Channel B to ensure uniqueness in the xarray
+index.  The nominal scan rate for each channel is every 30 minutes.
 
 Examples
 --------
@@ -24,8 +28,7 @@ Examples
 
     import datetime as dt
     import pysat
-    nmax = pysat.Instrument(platform='ses14', name='gold', tag='nmax'
-                            strict_time_flag=False)
+    nmax = pysat.Instrument(platform='ses14', name='gold', tag='nmax')
     nmax.download(dt.datetime(2020, 1, 1), dt.datetime(2020, 1, 31))
     nmax.load(2020, 1)
 

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -156,9 +156,16 @@ def load(fnames, tag='', inst_id=''):
                              drop_meta_labels='FILLVAL')
 
     if tag == 'nmax':
-        # Add time coordinate from scan_start_time
-        data['time'] = [dt.datetime.strptime(str(val), "b'%Y-%m-%dT%H:%M:%SZ'")
-                        for val in data['scan_start_time'].values]
+        # Add time coordinate from scan_start_time.
+        time = [dt.datetime.strptime(str(val), "b'%Y-%m-%dT%H:%M:%SZ'")
+                for val in data['scan_start_time'].values]
+
+        # Add a delta of 1 microsecond for channel B.
+        delta_time = [1 if ch == b'CHB' else 0 for ch in data['channel'].values]
+        data['time'] = [time[i] + dt.timedelta(microseconds=delta_time[i])
+                        for i in range(0, len(time))]
+
+        # Sort times to ensure monotonic increase.
         data = data.sortby('time')
 
         # Update coordinates with dimensional data


### PR DESCRIPTION
# Description

Addresses #139

GOLD nmax includes 2 independent channels, which occasionally have the same start time for a given sweep.  This leads to approximately 0.3% of daily files not having a unique index.

This adds one microsecond to the Channel B data to maintain uniqueness.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```
import datetime as dt
import pysat

date = dt.datetime(2019, 4, 17)

inst = pysat.Instrument('ses14', 'gold', tag='nmax', use_header=True)
inst.download(date, date)
inst.load(date=date)
```
In develop, this day returns `ValueError:  Loaded data is not unique.`
It loads correctly in this branch.

## Test Configuration
* Operating system: Monterrey
* Version number: python 3.10.8

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
