### PR TITLE
BUG: default label types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated dosctring style for consistency
   * Removed version cap for xarray
   * Added manual workflow to check that latest RC is installable through test pip
-  * Update meta label type for ICON instruments
+  * Update meta label type for instruments
 
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated dosctring style for consistency
   * Removed version cap for xarray
   * Added manual workflow to check that latest RC is installable through test pip
+  * Update meta label type for ICON instruments
 
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -212,8 +212,9 @@ def load(fnames, tag='', inst_id='', keep_original_names=False):
     """
     labels = {'units': ('Units', str), 'name': ('Long_Name', str),
               'notes': ('Var_Notes', str), 'desc': ('CatDesc', str),
-              'min_val': ('ValidMin', float),
-              'max_val': ('ValidMax', float), 'fill_val': ('FillVal', float)}
+              'min_val': ('ValidMin', (int, float)),
+              'max_val': ('ValidMax', (int, float)),
+              'fill_val': ('FillVal', (int, float))}
 
     meta_translation = {'FieldNam': 'plot'}
 

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -208,8 +208,9 @@ def load(fnames, tag='', inst_id='', keep_original_names=False):
     """
     labels = {'units': ('Units', str), 'name': ('Long_Name', str),
               'notes': ('Var_Notes', str), 'desc': ('CatDesc', str),
-              'min_val': ('ValidMin', float),
-              'max_val': ('ValidMax', float), 'fill_val': ('FillVal', float)}
+              'min_val': ('ValidMin', (int, float)),
+              'max_val': ('ValidMax', (int, float)),
+              'fill_val': ('FillVal', (int, float))}
 
     meta_translation = {'FieldNam': 'plot', 'LablAxis': 'axis',
                         'FIELDNAM': 'plot', 'LABLAXIS': 'axis',

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -272,8 +272,9 @@ def load(fnames, tag='', inst_id='', keep_original_names=False):
 
     labels = {'units': ('Units', str), 'name': ('Long_Name', str),
               'notes': ('Var_Notes', str), 'desc': ('CatDesc', str),
-              'min_val': ('ValidMin', float),
-              'max_val': ('ValidMax', float), 'fill_val': ('FillVal', float)}
+              'min_val': ('ValidMin', (int, float)),
+              'max_val': ('ValidMax', (int, float)),
+              'fill_val': ('FillVal', (int, float))}
 
     meta_translation = {'FieldNam': 'plot', 'LablAxis': 'axis',
                         'ScaleTyp': 'scale',

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -318,8 +318,9 @@ def load(fnames, tag='', inst_id='', keep_original_names=False):
     """
     labels = {'units': ('Units', str), 'name': ('Long_Name', str),
               'notes': ('Var_Notes', str), 'desc': ('CatDesc', str),
-              'min_val': ('ValidMin', float),
-              'max_val': ('ValidMax', float), 'fill_val': ('FillVal', float)}
+              'min_val': ('ValidMin', (int, float)),
+              'max_val': ('ValidMax', (int, float)),
+              'fill_val': ('FillVal', (int, float))}
 
     meta_translation = {'FieldNam': 'plot', 'LablAxis': 'axis',
                         'FIELDNAM': 'plot', 'LABLAXIS': 'axis',

--- a/pysatNASA/instruments/methods/_cdf.py
+++ b/pysatNASA/instruments/methods/_cdf.py
@@ -360,9 +360,9 @@ class CDF(object):
     def to_pysat(self, flatten_twod=True,
                  labels={'units': ('Units', str), 'name': ('Long_Name', str),
                          'notes': ('Var_Notes', str), 'desc': ('CatDesc', str),
-                         'min_val': ('ValidMin', float),
-                         'max_val': ('ValidMax', float),
-                         'fill_val': ('FillVal', float)}):
+                         'min_val': ('ValidMin', (int, float)),
+                         'max_val': ('ValidMax', (int, float)),
+                         'fill_val': ('FillVal', (int, float))}):
         """Export loaded CDF data into data, meta for pysat module.
 
         Parameters
@@ -382,9 +382,9 @@ class CDF(object):
             that order.
             (default={'units': ('units', str), 'name': ('long_name', str),
                       'notes': ('notes', str), 'desc': ('desc', str),
-                      'min_val': ('value_min', float),
-                      'max_val': ('value_max', float)
-                      'fill_val': ('fill', float)})
+                      'min_val': ('value_min', (int, float)),
+                      'max_val': ('value_max', (int, float))
+                      'fill_val': ('fill', (int, float))})
 
         Returns
         -------


### PR DESCRIPTION
# Description

A number of metadata values are dropped where the type is not a float.  This updates the standards so that both int and float are accepted by default.  See https://github.com/pysat/pysat/pull/1108

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested by running tests with both pysat `main` and https://github.com/pysat/pysat/pull/1108 and inspecting warning messages.

## Test Configuration
* Operating system: Monterrey
* Version number: Python 3.9.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
