### PR TITLE
BUG: excessive download requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.X.X] - 2023-XX-XX
+## [0.0.5] - 2023-XX-XX
 * New Instruments
   * ACE EPAM
   * ACE MAG
@@ -25,6 +25,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated GOLD nmax to sort scans by time.
   * Added 1 usec to GOLD nmax channel B times to ensure uniqueness
   * Fixed multi-file loads for cdf xarray datasets.
+  * Adds a 0.1 sec delay between file downloads to avoid excessive calls
+    to servers.
 * Documentation
   * Added TIMED-GUVI platform
   * Added missing sub-module imports

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -561,7 +561,7 @@ def download(date_array, tag='', inst_id='', supported_tags=None,
             logger.info(' '.join((str(exception), '- File not available for',
                                   date.strftime('%d %B %Y'))))
         # Pause to avoid excessive pings to server
-        sleep(0.1)
+        sleep(0.2)
     return
 
 
@@ -658,7 +658,7 @@ def cdas_download(date_array, tag='', inst_id='', supported_tags=None,
             logger.info(' '.join((str(exception), '- File: "', file,
                                   '" Is not available')))
         # Pause to avoid excessive pings to server
-        sleep(0.1)
+        sleep(0.2)
     return
 
 

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -13,6 +13,7 @@ import numpy as np
 import os
 import pandas as pds
 import requests
+import time
 import warnings
 import xarray as xr
 
@@ -549,6 +550,7 @@ def download(date_array, tag='', inst_id='', supported_tags=None,
         except requests.exceptions.RequestException as exception:
             logger.info(' '.join((str(exception), '- File not available for',
                                   date.strftime('%d %B %Y'))))
+        time.sleep(0.1)
     return
 
 
@@ -644,6 +646,7 @@ def cdas_download(date_array, tag='', inst_id='', supported_tags=None,
         except requests.exceptions.RequestException as exception:
             logger.info(' '.join((str(exception), '- File: "', file,
                                   '" Is not available')))
+        time.sleep(0.1)
     return
 
 

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -550,6 +550,7 @@ def download(date_array, tag='', inst_id='', supported_tags=None,
         except requests.exceptions.RequestException as exception:
             logger.info(' '.join((str(exception), '- File not available for',
                                   date.strftime('%d %B %Y'))))
+        # Pause to avoid excessive pings to server
         sleep(0.1)
     return
 
@@ -646,6 +647,7 @@ def cdas_download(date_array, tag='', inst_id='', supported_tags=None,
         except requests.exceptions.RequestException as exception:
             logger.info(' '.join((str(exception), '- File: "', file,
                                   '" Is not available')))
+        # Pause to avoid excessive pings to server
         sleep(0.1)
     return
 

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -13,7 +13,7 @@ import numpy as np
 import os
 import pandas as pds
 import requests
-import time
+from time import sleep
 import warnings
 import xarray as xr
 
@@ -550,7 +550,7 @@ def download(date_array, tag='', inst_id='', supported_tags=None,
         except requests.exceptions.RequestException as exception:
             logger.info(' '.join((str(exception), '- File not available for',
                                   date.strftime('%d %B %Y'))))
-        time.sleep(0.1)
+        sleep(0.1)
     return
 
 
@@ -646,7 +646,7 @@ def cdas_download(date_array, tag='', inst_id='', supported_tags=None,
         except requests.exceptions.RequestException as exception:
             logger.info(' '.join((str(exception), '- File: "', file,
                                   '" Is not available')))
-        time.sleep(0.1)
+        sleep(0.1)
     return
 
 


### PR DESCRIPTION
# Description

Addresses #172

When downloading numerous small files in close proximity to the data servers, sometimes the default code will return an excessive server request error.  This adds a brief pause after each download to avoid erroring.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running unit tests at locations where this issue arises.

## Test Configuration
* Operating system: Monterrey
* Version number: python 3.10
* Physically near the servers

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
