### PR TITLE
BUG: TIMED SABER and xarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * xarray support for TIMED SABER and SEE
   * Added `drop_dims` kwarg to `load_xarray` interface so that orphan dims can
     be removed before attempting to merge.
+  * Improved usage of cdflib for users in xarray instruments
 * Deprecations
   * Deprecated jpl_gps instrtument module, moved roti instrument to igs_gps
 * Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated GitHub Actions workflows for improved compliance with pip>=23.0
   * Added .readthedocs.yml to configure settings there.
   * Use pyproject.toml to manage installation and metadata
+  * Set use_cdflib=True for supported xarray instruments
 
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * xarray support for TIMED SABER and SEE
   * Added `drop_dims` kwarg to `load_xarray` interface so that orphan dims can
     be removed before attempting to merge.
+  * Added `var_translation` kwarg to `load_xarray` interface so that variables can
+    be renamed before attempting to merge.
   * Improved usage of cdflib for users in xarray instruments
 * Deprecations
   * Deprecated jpl_gps instrtument module, moved roti instrument to igs_gps

--- a/pysatNASA/instruments/ace_epam_l2.py
+++ b/pysatNASA/instruments/ace_epam_l2.py
@@ -92,7 +92,7 @@ meta_translation = {'CATDESC': 'desc', 'FILLVAL': 'fill',
                     'LABLAXIS': 'plot_label', 'VALIDMAX': 'value_max',
                     'VALIDMIN': 'value_min', 'VAR_NOTES': 'notes'}
 load = functools.partial(cdw.load, pandas_format=pandas_format,
-                         meta_translation=meta_translation)
+                         meta_translation=meta_translation, use_cdflib=True)
 
 # Set the download routine
 download_tags = {'12sec': {'base': 'AC_H3_EPM'},

--- a/pysatNASA/instruments/ace_mag_l2.py
+++ b/pysatNASA/instruments/ace_mag_l2.py
@@ -94,7 +94,7 @@ meta_translation = {'CATDESC': 'desc', 'FILLVAL': 'fill',
                     'LABLAXIS': 'plot_label', 'VALIDMAX': 'value_max',
                     'VALIDMIN': 'value_min', 'VAR_NOTES': 'notes'}
 load = functools.partial(cdw.load, pandas_format=pandas_format,
-                         meta_translation=meta_translation)
+                         meta_translation=meta_translation, use_cdflib=True)
 
 # Set the download routine
 download_tags = {'1sec': {'base': 'AC_H3_MFI'},

--- a/pysatNASA/instruments/ace_sis_l2.py
+++ b/pysatNASA/instruments/ace_sis_l2.py
@@ -87,7 +87,7 @@ meta_translation = {'CATDESC': 'desc', 'FILLVAL': 'fill',
                     'LABLAXIS': 'plot_label', 'VALIDMAX': 'value_max',
                     'VALIDMIN': 'value_min', 'VAR_NOTES': 'notes'}
 load = functools.partial(cdw.load, pandas_format=pandas_format,
-                         meta_translation=meta_translation)
+                         meta_translation=meta_translation, use_cdflib=True)
 
 # Set the download routine
 download_tags = {'256sec': {'base': 'AC_H1_SIS'},

--- a/pysatNASA/instruments/ace_swepam_l2.py
+++ b/pysatNASA/instruments/ace_swepam_l2.py
@@ -90,7 +90,7 @@ meta_translation = {'CATDESC': 'desc', 'FILLVAL': 'fill',
                     'LABLAXIS': 'plot_label', 'VALIDMAX': 'value_max',
                     'VALIDMIN': 'value_min', 'VAR_NOTES': 'notes'}
 load = functools.partial(cdw.load, pandas_format=pandas_format,
-                         meta_translation=meta_translation)
+                         meta_translation=meta_translation, use_cdflib=True)
 
 # Set the download routine
 download_tags = {'64sec': {'base': 'AC_H0_SWE'},

--- a/pysatNASA/instruments/igs_gps.py
+++ b/pysatNASA/instruments/igs_gps.py
@@ -123,7 +123,8 @@ list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # Set the load routine
-load = functools.partial(cdw.load, pandas_format=pandas_format)
+load = functools.partial(cdw.load, pandas_format=pandas_format,
+                         use_cdflib=True)
 
 # Set the download routine
 download = functools.partial(cdw.cdas_download, supported_tags=cdas_labels)

--- a/pysatNASA/instruments/jpl_gps.py
+++ b/pysatNASA/instruments/jpl_gps.py
@@ -113,7 +113,8 @@ list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # Set the load routine
-load = functools.partial(cdw.load, pandas_format=pandas_format)
+load = functools.partial(cdw.load, pandas_format=pandas_format,
+                         use_cdflib=True)
 
 # Set the download routine
 download_tags = {'': {'roti': 'GPS_ROTI15MIN_JPL'}}

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -381,7 +381,8 @@ def load_xarray(fnames, tag='', inst_id='',
 
         # Combine individual files together, concat along epoch
         if len(ldata) > 0:
-            data = xr.combine_nested(ldata, epoch_name)
+            data = xr.combine_nested(ldata, epoch_name,
+                                     combine_attrs='override')
 
     all_vars = io.xarray_all_vars(data)
 
@@ -401,8 +402,8 @@ def load_xarray(fnames, tag='', inst_id='',
 
     for key in all_vars:
         meta_dict = {}
-        for nc_key in ldata[0][key].attrs.keys():
-            meta_dict[nc_key] = ldata[0][key].attrs[nc_key]
+        for nc_key in data[key].attrs.keys():
+            meta_dict[nc_key] = data[key].attrs[nc_key]
         full_mdict[key] = meta_dict
         data[key].attrs = {}
 
@@ -438,6 +439,7 @@ def load_xarray(fnames, tag='', inst_id='',
         meta[key] = filt_mdict[key]
 
     # Convert output epoch name to 'time' for pysat consistency
+    # This needs to be done last so that meta is updated properly
     if epoch_name != 'time':
         if 'time' not in all_vars:
             if epoch_name in data.dims:

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -64,7 +64,7 @@ def try_inst_dict(inst_id, tag, supported_tags):
 
 def load(fnames, tag='', inst_id='', file_cadence=dt.timedelta(days=1),
          flatten_twod=True, pandas_format=True, epoch_name='Epoch',
-         drop_dims=None, drop_vars=None, meta_processor=None,
+         drop_dims=None, var_translation=None, meta_processor=None,
          meta_translation=None, drop_meta_labels=None, use_cdflib=None):
     """Load NASA CDAWeb CDF files.
 
@@ -97,8 +97,8 @@ def load(fnames, tag='', inst_id='', file_cadence=dt.timedelta(days=1),
         List of variable dimensions that should be dropped. Applied
         to data as loaded from the file. Used only from xarray Dataset.
         (default=None)
-    drop_vars : list or NoneType
-        List of variables that should be dropped. Applied to data as loaded
+    var_translation : dict or NoneType
+        Variables that should be renamed. Applied to data as loaded
         from the file. Used only from xarray Dataset. (default=None)
     meta_processor : function or NoneType
         If not None, a dict containing all of the loaded metadata will be
@@ -151,7 +151,7 @@ def load(fnames, tag='', inst_id='', file_cadence=dt.timedelta(days=1),
         data, meta = load_xarray(fnames, tag=tag, inst_id=inst_id,
                                  epoch_name=epoch_name,
                                  drop_dims=drop_dims,
-                                 drop_vars=drop_vars,
+                                 var_translation=var_translation,
                                  file_cadence=file_cadence,
                                  meta_processor=meta_processor,
                                  meta_translation=meta_translation,
@@ -270,10 +270,10 @@ def load_xarray(fnames, tag='', inst_id='',
                 file_cadence=dt.timedelta(days=1),
                 labels={'units': ('Units', str), 'name': ('Long_Name', str),
                         'notes': ('Var_Notes', str), 'desc': ('CatDesc', str),
-                        'min_val': ('ValidMin', float),
-                        'max_val': ('ValidMax', float),
-                        'fill_val': ('FillVal', float)},
-                epoch_name='Epoch', drop_dims=None, drop_vars=None,
+                        'min_val': ('ValidMin', (int, float)),
+                        'max_val': ('ValidMax', (int, float)),
+                        'fill_val': ('FillVal', (int, float))},
+                epoch_name='Epoch', drop_dims=None, var_translation=None,
                 meta_processor=None, meta_translation=None,
                 drop_meta_labels=None):
     """Load NASA CDAWeb CDF files into an xarray Dataset.
@@ -308,9 +308,9 @@ def load_xarray(fnames, tag='', inst_id='',
     drop_dims : list or NoneType
         List of variable dimensions that should be dropped. Applied
         to data as loaded from the file. (default=None)
-    drop_vars : list or NoneType
-        List of variables that should be dropped. Applied to data as loaded
-        from the file. (default=None)
+    var_translation : dict or NoneType
+        Variables that should be renamed. Applied to data as loaded
+        from the file. Used only from xarray Dataset. (default=None)
     meta_processor : function or NoneType
         If not None, a dict containing all of the loaded metadata will be
         passed to `meta_processor` which should return a filtered version
@@ -375,8 +375,8 @@ def load_xarray(fnames, tag='', inst_id='',
             temp_data = cdflib.cdf_to_xarray(lfname, to_datetime=True)
             if drop_dims:
                 temp_data = temp_data.drop_dims(drop_dims)
-            if drop_vars:
-                temp_data = temp_data.drop_vars(drop_vars)
+            if var_translation:
+                temp_data = temp_data.rename(var_translation)
             ldata.append(temp_data)
 
         # Combine individual files together, concat along epoch

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -385,26 +385,6 @@ def load_xarray(fnames, tag='', inst_id='',
 
     all_vars = io.xarray_all_vars(data)
 
-    # Convert output epoch name to 'time' for pysat consistency
-    if epoch_name != 'time':
-        if 'time' not in all_vars:
-            if epoch_name in data.dims:
-                data = data.rename({epoch_name: 'time'})
-            elif epoch_name in all_vars:
-                data = data.rename({epoch_name: 'time'})
-                wstr = ''.join(['Epoch label: "', epoch_name, '"',
-                                ' is not a dimension.'])
-                pysat.logger.warning(wstr)
-            else:
-                estr = ''.join(['Epoch label: "', epoch_name, '"',
-                                ' not found in loaded data, ',
-                                repr(all_vars)])
-                raise ValueError(estr)
-
-        epoch_name = 'time'
-
-    all_vars = io.xarray_all_vars(data)
-
     meta = pysat.Meta(labels=labels)
 
     full_mdict = {}
@@ -421,8 +401,8 @@ def load_xarray(fnames, tag='', inst_id='',
 
     for key in all_vars:
         meta_dict = {}
-        for nc_key in data[key].attrs.keys():
-            meta_dict[nc_key] = data[key].attrs[nc_key]
+        for nc_key in ldata[0][key].attrs.keys():
+            meta_dict[nc_key] = ldata[0][key].attrs[nc_key]
         full_mdict[key] = meta_dict
         data[key].attrs = {}
 
@@ -456,6 +436,24 @@ def load_xarray(fnames, tag='', inst_id='',
     # Assign filtered metadata to pysat.Meta instance
     for key in filt_mdict:
         meta[key] = filt_mdict[key]
+
+    # Convert output epoch name to 'time' for pysat consistency
+    if epoch_name != 'time':
+        if 'time' not in all_vars:
+            if epoch_name in data.dims:
+                data = data.rename({epoch_name: 'time'})
+            elif epoch_name in all_vars:
+                data = data.rename({epoch_name: 'time'})
+                wstr = ''.join(['Epoch label: "', epoch_name, '"',
+                                ' is not a dimension.'])
+                pysat.logger.warning(wstr)
+            else:
+                estr = ''.join(['Epoch label: "', epoch_name, '"',
+                                ' not found in loaded data, ',
+                                repr(all_vars)])
+                raise ValueError(estr)
+
+        epoch_name = 'time'
 
     # Remove attributes from the data object
     data.attrs = {}

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -64,8 +64,8 @@ def try_inst_dict(inst_id, tag, supported_tags):
 
 def load(fnames, tag='', inst_id='', file_cadence=dt.timedelta(days=1),
          flatten_twod=True, pandas_format=True, epoch_name='Epoch',
-         drop_dims=None, meta_processor=None, meta_translation=None,
-         drop_meta_labels=None, use_cdflib=None):
+         drop_dims=None, drop_vars=None, meta_processor=None,
+         meta_translation=None, drop_meta_labels=None, use_cdflib=None):
     """Load NASA CDAWeb CDF files.
 
     Parameters
@@ -97,6 +97,9 @@ def load(fnames, tag='', inst_id='', file_cadence=dt.timedelta(days=1),
         List of variable dimensions that should be dropped. Applied
         to data as loaded from the file. Used only from xarray Dataset.
         (default=None)
+    drop_vars : list or NoneType
+        List of variables that should be dropped. Applied to data as loaded
+        from the file. Used only from xarray Dataset. (default=None)
     meta_processor : function or NoneType
         If not None, a dict containing all of the loaded metadata will be
         passed to `meta_processor` which should return a filtered version
@@ -148,6 +151,7 @@ def load(fnames, tag='', inst_id='', file_cadence=dt.timedelta(days=1),
         data, meta = load_xarray(fnames, tag=tag, inst_id=inst_id,
                                  epoch_name=epoch_name,
                                  drop_dims=drop_dims,
+                                 drop_vars=drop_vars,
                                  file_cadence=file_cadence,
                                  meta_processor=meta_processor,
                                  meta_translation=meta_translation,
@@ -269,8 +273,9 @@ def load_xarray(fnames, tag='', inst_id='',
                         'min_val': ('ValidMin', float),
                         'max_val': ('ValidMax', float),
                         'fill_val': ('FillVal', float)},
-                epoch_name='Epoch', drop_dims=None, meta_processor=None,
-                meta_translation=None, drop_meta_labels=None):
+                epoch_name='Epoch', drop_dims=None, drop_vars=None,
+                meta_processor=None, meta_translation=None,
+                drop_meta_labels=None):
     """Load NASA CDAWeb CDF files into an xarray Dataset.
 
     Parameters
@@ -303,6 +308,9 @@ def load_xarray(fnames, tag='', inst_id='',
     drop_dims : list or NoneType
         List of variable dimensions that should be dropped. Applied
         to data as loaded from the file. (default=None)
+    drop_vars : list or NoneType
+        List of variables that should be dropped. Applied to data as loaded
+        from the file. (default=None)
     meta_processor : function or NoneType
         If not None, a dict containing all of the loaded metadata will be
         passed to `meta_processor` which should return a filtered version
@@ -367,6 +375,8 @@ def load_xarray(fnames, tag='', inst_id='',
             temp_data = cdflib.cdf_to_xarray(lfname, to_datetime=True)
             if drop_dims:
                 temp_data = temp_data.drop_dims(drop_dims)
+            if drop_vars:
+                temp_data = temp_data.drop_vars(drop_vars)
             ldata.append(temp_data)
 
         # Combine individual files together, concat along epoch

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -98,9 +98,8 @@ supported_tags = {'': {'': fname}}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
-# Set the load routine
-# Note that the time variable associated with tpaltitude is renamed to avoid
-# conflict with renaming Epoch.
+# Set the load routine. Note that the time variable associated with
+# tpaltitude is renamed to avoid conflict with renaming Epoch.
 load = functools.partial(cdw.load, pandas_format=pandas_format,
                          drop_dims='record0',
                          var_translation={'time': 'tp_time'},

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -99,10 +99,11 @@ list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # Set the load routine
-# Note that duplicate string and variables to Epoch are dropped to aid in
-# concatonation of files.
+# Note that the time variable associated with tpaltitude is renamed to avoid
+# conflict with renaming Epoch.
 load = functools.partial(cdw.load, pandas_format=pandas_format,
-                         drop_dims='record0', drop_vars='time',
+                         drop_dims='record0',
+                         var_translation={'time': 'tp_time'},
                          use_cdflib=True)
 
 # Set the download routine

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -99,8 +99,11 @@ list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # Set the load routine
+# Note that duplicate string and variables to Epoch are dropped to aid in
+# concatonation of files.
 load = functools.partial(cdw.load, pandas_format=pandas_format,
-                         drop_dims='record0')
+                         drop_dims='record0', drop_vars='time',
+                         use_cdflib=True)
 
 # Set the download routine
 download_tags = {'': {'': 'TIMED_L2A_SABER'}}

--- a/pysatNASA/instruments/timed_see.py
+++ b/pysatNASA/instruments/timed_see.py
@@ -77,8 +77,8 @@ list_files = functools.partial(mm_gen.list_files,
                                file_cadence=pds.DateOffset(months=1))
 
 # Set the load routine
-load = functools.partial(cdw.load, pandas_format=pandas_format,
-                         file_cadence=pds.DateOffset(months=1))
+load = functools.partial(cdw.load, file_cadence=pds.DateOffset(months=1),
+                         pandas_format=pandas_format, use_cdflib=True)
 
 # Set the download routine
 download_tags = {'': {'': 'TIMED_L3A_SEE'}}


### PR DESCRIPTION
# Description

Addresses #174

TIMED SABER has an extra variable for time, for use with the tpaltitude profiles.  This means that 'Epoch' will not be renamed 'time', breaking the new expand_dims code in pysat 3.1.0.

BONUS BUG: when multiple xarray files are combined via `xr.combine_nested`, the attrs for each variable are dropped, meaning that meta is not set for each variable.  

- Renames the profile time variable as 'tp_time', fixing the bug.
- `xr.combine_nested` now uses the kwarg `combine_attrs='override'` to use the attrs from the first file.
- Uses the kwarg `use_cdflib=True` for xarray objects to suppress warning message.  pysatCDF does not currently support xarray, so this can be hard wired

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Loading a day of data and inspecting the metadata.

```
import pysat
saber = pysat.Instrument('timed', 'saber', use_header=True)
saber.load(2019, 1)
saber.meta['tp_time']
```

## Test Configuration
* Operating system: Monterrey
* Version number: python 3.9.7
* pysat 3.1.0

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
