### PR TITLE
ENH: strict_dim_check kwarg and jhuapl load routines

### DIFF
--- a/pysatNASA/instruments/dmsp_ssusi.py
+++ b/pysatNASA/instruments/dmsp_ssusi.py
@@ -106,7 +106,8 @@ list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # Set the load routine
-load = functools.partial(jhuapl.load_edr_aurora, pandas_format=pandas_format)
+load = functools.partial(jhuapl.load_edr_aurora, pandas_format=pandas_format,
+                         strict_dim_check=False)
 
 # Set the download routine
 basic_tag = {'remote_dir': ''.join(('/pub/data/dmsp/dmsp{inst_id:s}/ssusi/',

--- a/pysatNASA/instruments/methods/jhuapl.py
+++ b/pysatNASA/instruments/methods/jhuapl.py
@@ -135,7 +135,8 @@ def expand_coords(data_list, mdata, dims_equal=False):
     return out_list
 
 
-def load_edr_aurora(fnames, tag='', inst_id='', pandas_format=False):
+def load_edr_aurora(fnames, tag='', inst_id='', pandas_format=False,
+                    strict_dim_check=True):
     """Load JHU APL EDR Aurora data and meta data.
 
     Parameters
@@ -149,6 +150,10 @@ def load_edr_aurora(fnames, tag='', inst_id='', pandas_format=False):
         (default='')
     pandas_format : bool
         False for xarray format, True for pandas (default=False)
+    strict_dim_check : bool
+        Used for xarray data (`pandas_format` is False). If True, warn the user
+        that the desired epoch is not present in `xarray.dims`.  If False,
+        no warning is raised. (default=True)
 
     Returns
     -------
@@ -180,7 +185,8 @@ def load_edr_aurora(fnames, tag='', inst_id='', pandas_format=False):
         # than a dimension or coordinate.  Additionally, no coordinates
         # are assigned.
         sdata, mdata = load_netcdf(fname, epoch_name='TIME', epoch_unit='s',
-                                   labels=labels, pandas_format=pandas_format)
+                                   labels=labels, pandas_format=pandas_format,
+                                   strict_dim_check=strict_dim_check)
 
         # Calculate the time for this data file. The pysat `load_netcdf` routine
         # converts the 'TIME' parameter (seconds of day) into datetime using

--- a/pysatNASA/instruments/methods/jhuapl.py
+++ b/pysatNASA/instruments/methods/jhuapl.py
@@ -224,7 +224,7 @@ def load_edr_aurora(fnames, tag='', inst_id='', pandas_format=False,
 
 
 def load_sdr_aurora(fnames, tag='', inst_id='', pandas_format=False,
-                    combine_times=False):
+                    strict_dim_check=True, combine_times=False):
     """Load JHU APL SDR data and meta data.
 
     Parameters
@@ -238,6 +238,10 @@ def load_sdr_aurora(fnames, tag='', inst_id='', pandas_format=False,
         (default='')
     pandas_format : bool
         False for xarray format, True for pandas (default=False)
+    strict_dim_check : bool
+        Used for xarray data (`pandas_format` is False). If True, warn the user
+        that the desired epoch is not present in `xarray.dims`.  If False,
+        no warning is raised. (default=True)
     combine_times : bool
         For SDR data, optionally combine the different datetime coordinates
         into a single time coordinate (default=False)

--- a/pysatNASA/instruments/methods/jhuapl.py
+++ b/pysatNASA/instruments/methods/jhuapl.py
@@ -310,7 +310,8 @@ def load_sdr_aurora(fnames, tag='', inst_id='', pandas_format=False,
         # than a dimension or coordinate.  Additionally, no coordinates
         # are assigned.
         sdata, mdata = load_netcdf(fname, epoch_name=load_time, epoch_unit='s',
-                                   labels=labels, pandas_format=pandas_format)
+                                   labels=labels, pandas_format=pandas_format,
+                                   strict_dim_check=strict_dim_check)
 
         # Calculate the time for this data file. The pysat `load_netcdf` routine
         # converts the 'TIME' parameter (seconds of day) into datetime using

--- a/pysatNASA/instruments/methods/jhuapl.py
+++ b/pysatNASA/instruments/methods/jhuapl.py
@@ -152,8 +152,8 @@ def load_edr_aurora(fnames, tag='', inst_id='', pandas_format=False,
         False for xarray format, True for pandas (default=False)
     strict_dim_check : bool
         Used for xarray data (`pandas_format` is False). If True, warn the user
-        that the desired epoch, NAME, is not present as a dimension in the NetCDF file.  If False,
-        no warning is raised. (default=True)
+        that the desired epoch, NAME, is not present as a dimension in the 
+        NetCDF file.  If False, no warning is raised. (default=True)
 
     Returns
     -------

--- a/pysatNASA/instruments/methods/jhuapl.py
+++ b/pysatNASA/instruments/methods/jhuapl.py
@@ -152,7 +152,7 @@ def load_edr_aurora(fnames, tag='', inst_id='', pandas_format=False,
         False for xarray format, True for pandas (default=False)
     strict_dim_check : bool
         Used for xarray data (`pandas_format` is False). If True, warn the user
-        that the desired epoch is not present in `xarray.dims`.  If False,
+        that the desired epoch, NAME, is not present as a dimension in the NetCDF file.  If False,
         no warning is raised. (default=True)
 
     Returns

--- a/pysatNASA/instruments/methods/jhuapl.py
+++ b/pysatNASA/instruments/methods/jhuapl.py
@@ -152,7 +152,7 @@ def load_edr_aurora(fnames, tag='', inst_id='', pandas_format=False,
         False for xarray format, True for pandas (default=False)
     strict_dim_check : bool
         Used for xarray data (`pandas_format` is False). If True, warn the user
-        that the desired epoch, NAME, is not present as a dimension in the
+        that the desired epoch,'TIME', is not present as a dimension in the
         NetCDF file.  If False, no warning is raised. (default=True)
 
     Returns

--- a/pysatNASA/instruments/methods/jhuapl.py
+++ b/pysatNASA/instruments/methods/jhuapl.py
@@ -152,7 +152,7 @@ def load_edr_aurora(fnames, tag='', inst_id='', pandas_format=False,
         False for xarray format, True for pandas (default=False)
     strict_dim_check : bool
         Used for xarray data (`pandas_format` is False). If True, warn the user
-        that the desired epoch,'TIME', is not present as a dimension in the
+        that the desired epoch, 'TIME', is not present as a dimension in the
         NetCDF file.  If False, no warning is raised. (default=True)
 
     Returns
@@ -240,8 +240,8 @@ def load_sdr_aurora(fnames, tag='', inst_id='', pandas_format=False,
         False for xarray format, True for pandas (default=False)
     strict_dim_check : bool
         Used for xarray data (`pandas_format` is False). If True, warn the user
-        that the desired epoch is not present in `xarray.dims`.  If False,
-        no warning is raised. (default=True)
+        that the desired epoch, 'TIME_DAY', is not present as a dimension in the
+        NetCDF file.  If False, no warning is raised. (default=True)```
     combine_times : bool
         For SDR data, optionally combine the different datetime coordinates
         into a single time coordinate (default=False)

--- a/pysatNASA/instruments/methods/jhuapl.py
+++ b/pysatNASA/instruments/methods/jhuapl.py
@@ -152,7 +152,7 @@ def load_edr_aurora(fnames, tag='', inst_id='', pandas_format=False,
         False for xarray format, True for pandas (default=False)
     strict_dim_check : bool
         Used for xarray data (`pandas_format` is False). If True, warn the user
-        that the desired epoch, NAME, is not present as a dimension in the 
+        that the desired epoch, NAME, is not present as a dimension in the
         NetCDF file.  If False, no warning is raised. (default=True)
 
     Returns

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -188,10 +188,12 @@ def load(fnames, tag='', inst_id='', combine_times=False):
     """
     if tag == 'edr-aur':
         data, meta = jhuapl.load_edr_aurora(fnames, tag, inst_id,
-                                            pandas_format=pandas_format)
+                                            pandas_format=pandas_format,
+                                            strict_dim_check=False)
     else:
         data, meta = jhuapl.load_sdr_aurora(fnames, tag, inst_id,
                                             pandas_format=pandas_format,
-                                            combine_times=combine_times)
+                                            combine_times=combine_times,
+                                            strict_dim_check=False)
 
     return data, meta

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -193,7 +193,7 @@ def load(fnames, tag='', inst_id='', combine_times=False):
     else:
         data, meta = jhuapl.load_sdr_aurora(fnames, tag, inst_id,
                                             pandas_format=pandas_format,
-                                            combine_times=combine_times,
-                                            strict_dim_check=False)
+                                            strict_dim_check=False,
+                                            combine_times=combine_times)
 
     return data, meta


### PR DESCRIPTION
# Description

Passes the `strict_dim_check` kwarg through the load routines for auroral imager data in jhuapl methods.  Follows the convention for use_cdflib in that the default option raises warnings if new instruments are added with this routine, but existing instruments that are understood suppress the warning.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Loading data for dmsp ssusi and timed guvi.  Also inspecting the logs in GA.

## Test Configuration
* Operating system: Monterrey
* Version number: python 3.9.7
* Requires pysat 3.1.0

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [na] Add a note to ``CHANGELOG.md``, summarizing the changes -- ***instruments affected are new to this version***
- [x] Update zenodo.json file for new code contributors
