### PR TITLE
MAINT: pysat 3.1.0 limitation, clean up GOLD code, cdflib version cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added .readthedocs.yml to configure settings there.
   * Use pyproject.toml to manage installation and metadata
   * Set use_cdflib=True for supported xarray instruments
+  * Set pysat 3.1.0 minimum
 
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Python 3.6+.
 | Common modules   | Community modules | Optional Modules |
 | ---------------- | ----------------- |------------------|
 | beautifulsoup4   | cdflib            | pysatCDF         |
-| lxml             | pysat>=3.0.4      |                  |
+| lxml             | pysat>=3.1.0      |                  |
 | netCDF4          |                   |                  |
 | numpy            |                   |                  |
 | pandas           |                   |                  |

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,7 @@ Python 3.8+ and pysat 3.0.4+.
  Common modules     Community modules
  ================== =================
   beautifulsoup4     cdflib>=0.4.4
-  lxml               pysat>=3.0.4
+  lxml               pysat>=3.1.0
   netCDF4
   numpy
   pandas

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ Prerequisites
 
 pysatNASA uses common Python modules, as well as modules developed by
 and for the Space Physics community.  This module officially supports
-Python 3.8+ and pysat 3.0.4+.
+Python 3.8+ and pysat 3.1.0+.
 
  ================== =================
  Common modules     Community modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ keywords = [
 dependencies = [
   "beautifulsoup4",
   "cdasws",
-  "cdflib >= 0.4.4",
+  "cdflib >= 0.4.4, <1.0",
   "lxml",
   "netCDF4",
   "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "netCDF4",
   "numpy",
   "pandas",
-  "pysat >= 3.0.4",
+  "pysat >= 3.1",
   "requests",
   "xarray"
 ]

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -244,21 +244,11 @@ def load(fnames, tag='', inst_id=''):
     elif tag == 'o2den':
         epoch_name = 'nevents'
 
-    # TODO(#165): remove try/except notation once pysat 3.1.0 is released
-    try:
-        data, meta = load_netcdf(fnames, pandas_format=pandas_format,
-                                 epoch_name=epoch_name, labels=labels,
-                                 meta_translation=meta_translation,
-                                 combine_by_coords=False,
-                                 drop_meta_labels='FILLVAL')
-    except TypeError:
-        pysat.logger.warn(' '.join(("Loading multiple days of data may error.",
-                                    "Upgrade to pysat 3.1.0 or higher to",
-                                    "resolve this issue.")))
-        data, meta = load_netcdf(fnames, pandas_format=pandas_format,
-                                 epoch_name=epoch_name, labels=labels,
-                                 meta_translation=meta_translation,
-                                 drop_meta_labels='FILLVAL')
+    data, meta = load_netcdf(fnames, pandas_format=pandas_format,
+                             epoch_name=epoch_name, labels=labels,
+                             meta_translation=meta_translation,
+                             combine_by_coords=False,
+                             drop_meta_labels='FILLVAL')
 
     if tag in ['nmax', 'tdisk', 'tlimb']:
         # Add time coordinate from scan_start_time

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -42,7 +42,6 @@ import datetime as dt
 import functools
 import numpy as np
 
-import pysat
 from pysat.instruments.methods import general as ps_gen
 from pysat.utils.io import load_netcdf
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ lxml
 netCDF4
 numpy
 pandas
-pysat>=3.0.4
+pysat>=3.1.0
 requests
 xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4
 cdasws
-cdflib>=0.4.4
+cdflib>=0.4.4,<1.0
 lxml
 netCDF4
 numpy


### PR DESCRIPTION
# Description

Addresses #165

Adds a minimum version of pysat 3.1.0.  Cleans up the GOLD try except notation that was a temporary workaround since it required new pysat features.

***EDIT***: adds a temporary version cap for cdflib to allow the chain of bug fixes for pysat 3.1.0 to move forward while the breaking changes in cdflib 1.0+ are sorted.  See #179 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Github Actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
