### PR TITLE
Data path arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Deprecations
   * Deprecated jpl_gps instrtument module, moved roti instrument to igs_gps
 * Maintenance
+  * Updated download functions to take data_path as an arg, not a kwarg
   * Removed duplicate tests if pysatCDF not isntalled
   * Removed pysatCDF tests on GitHub Actions workflows (see #167)
   * Updated actions and templates based on pysatEcosystem docs

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -470,8 +470,8 @@ def load_xarray(fnames, tag='', inst_id='',
 
 
 # TODO(#103): Include support to unzip / untar files after download.
-def download(date_array, tag='', inst_id='', supported_tags=None,
-             remote_url='https://cdaweb.gsfc.nasa.gov', data_path=None):
+def download(date_array, data_path, tag='', inst_id='', supported_tags=None,
+             remote_url='https://cdaweb.gsfc.nasa.gov'):
     """Download NASA CDAWeb data.
 
     This routine is intended to be used by pysat instrument modules supporting
@@ -481,6 +481,8 @@ def download(date_array, tag='', inst_id='', supported_tags=None,
     ----------
     date_array : array-like
         Array of datetimes to download data for. Provided by pysat.
+    data_path : str
+        Path to data directory.
     tag : str
         Data product tag (default='')
     inst_id : str
@@ -493,9 +495,6 @@ def download(date_array, tag='', inst_id='', supported_tags=None,
     remote_url : str
         Remote site to download data from
         (default='https://cdaweb.gsfc.nasa.gov')
-    data_path : str or NoneType
-        Path to data directory.  If None is specified, the value previously
-        set in Instrument.files.data_path is used.  (default=None)
 
     Examples
     --------
@@ -570,8 +569,8 @@ def download(date_array, tag='', inst_id='', supported_tags=None,
     return
 
 
-def cdas_download(date_array, tag='', inst_id='', supported_tags=None,
-                  data_path=None):
+def cdas_download(date_array, data_path, tag='', inst_id='',
+                  supported_tags=None):
     """Download NASA CDAWeb CDF data using cdasws.
 
     This routine is intended to be used by pysat instrument modules supporting
@@ -581,6 +580,8 @@ def cdas_download(date_array, tag='', inst_id='', supported_tags=None,
     ----------
     date_array : array-like
         Array of datetimes to download data for. Provided by pysat.
+    data_path : str
+        Path to data directory.
     tag : str
         Data product tag (default='')
     inst_id : str
@@ -590,9 +591,6 @@ def cdas_download(date_array, tag='', inst_id='', supported_tags=None,
         a dict with 'remote_dir', 'fname'. Inteded to be pre-set with
         functools.partial then assigned to new instrument code.
         (default=None)
-    data_path : str or NoneType
-        Path to data directory.  If None is specified, the value previously
-        set in Instrument.files.data_path is used.  (default=None)
 
     Note
     ----

--- a/pysatNASA/tests/test_methods_cdaweb.py
+++ b/pysatNASA/tests/test_methods_cdaweb.py
@@ -19,6 +19,7 @@ class TestCDAWeb(object):
 
         self.download_tags = pysatNASA.instruments.timed_guvi.download_tags
         self.kwargs = {'tag': None, 'inst_id': None}
+        self.saved_path = pysat.params['data_dirs']
         return
 
     def teardown_method(self):
@@ -61,6 +62,7 @@ class TestCDAWeb(object):
         with pytest.raises(ValueError) as excinfo:
             cdw.download(supported_tags=self.download_tags,
                          date_array=date_array,
+                         data_path=self.saved_path,
                          tag=self.kwargs['tag'],
                          inst_id=self.kwargs['inst_id'])
         assert str(excinfo.value).find(err_msg) >= 0


### PR DESCRIPTION
# Description

Addresses #166 

pysat style is updating data_path to be input as an arg, not a kwarg. Affects download, etc.
So the download functions in the cdaweb methods have been updated accordingly

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- local pytest with python 3.9

## Test Configuration
* Operating system: [Mac OS 13.4]
* Version number: [Python 3.9]
* Conda environment

# Checklist:

- [X] Make sure you are merging into the ``develop`` (not ``main``) branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] Add a note to ``CHANGELOG.md``, summarizing the changes
- [ ] Update zenodo.json file for new code contributors
