### PR TITLE
MAINT: decode times kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Use pysat logger to raise non-deprecation warnings
   * Update syntax based on latest pysat deprecations to make the code compatible with pysat 3.2.0.
   * Updated syntax compliance with cdflib 1.0+
+  * Updated usage of `decode_times` kwarg to maintain usage in xarray
 
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Use pysat logger to raise non-deprecation warnings
   * Update syntax based on latest pysat deprecations to make the code compatible with pysat 3.2.0.
   * Updated syntax compliance with cdflib 1.0+
-  * Updated usage of `decode_times` kwarg to maintain usage in xarray
+  * Updated use of `decode_times` kwarg when loading xarray data to maintain current behaviour
 
 ## [0.0.4] - 2022-11-07
 * Update instrument tests with new test class

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -225,7 +225,8 @@ def load(fnames, tag='', inst_id='', keep_original_names=False):
                                             meta_translation=meta_translation,
                                             drop_meta_labels=['Valid_Max',
                                                               'Valid_Min',
-                                                              '_FillValue'])
+                                                              '_FillValue'],
+                                            decode_times=False)
 
     # xarray can't merge if variable and dim names are the same
     if 'Altitude' in data.dims:

--- a/pysatNASA/instruments/icon_fuv.py
+++ b/pysatNASA/instruments/icon_fuv.py
@@ -224,5 +224,6 @@ def load(fnames, tag='', inst_id='', keep_original_names=False):
                                             meta_kwargs={'labels': labels},
                                             meta_processor=filter_metadata,
                                             meta_translation=meta_translation,
-                                            drop_meta_labels=drop_labels)
+                                            drop_meta_labels=drop_labels,
+                                            decode_times=False)
     return data, meta

--- a/pysatNASA/instruments/icon_mighti.py
+++ b/pysatNASA/instruments/icon_mighti.py
@@ -336,7 +336,8 @@ def load(fnames, tag='', inst_id='', keep_original_names=False):
                                                               'Valid_Min',
                                                               'Valid_Range',
                                                               '_Fillvalue',
-                                                              'ScaleTyp'])
+                                                              'ScaleTyp'],
+                                            decode_times=False)
 
     # xarray can't merge if variable and dim names are the same
     if 'Altitude' in data.dims:

--- a/pysatNASA/instruments/methods/jhuapl.py
+++ b/pysatNASA/instruments/methods/jhuapl.py
@@ -112,6 +112,7 @@ def load_edr_aurora(fnames, tag='', inst_id='', pandas_format=False,
         sdata, mdata = load_netcdf(fname, epoch_name='TIME', epoch_unit='s',
                                    meta_kwargs={'labels': labels},
                                    pandas_format=pandas_format,
+                                   decode_times=False,
                                    strict_dim_check=strict_dim_check)
 
         # Calculate the time for this data file. The pysat `load_netcdf` routine
@@ -238,6 +239,7 @@ def load_sdr_aurora(fnames, tag='', inst_id='', pandas_format=False,
         sdata, mdata = load_netcdf(fname, epoch_name=load_time, epoch_unit='s',
                                    meta_kwargs={'labels': labels},
                                    pandas_format=pandas_format,
+                                   decode_times=False,
                                    strict_dim_check=strict_dim_check)
 
         # Calculate the time for this data file. The pysat `load_netcdf` routine

--- a/pysatNASA/instruments/ses14_gold.py
+++ b/pysatNASA/instruments/ses14_gold.py
@@ -248,7 +248,8 @@ def load(fnames, tag='', inst_id=''):
                              meta_kwargs={'labels': labels},
                              meta_translation=meta_translation,
                              combine_by_coords=False,
-                             drop_meta_labels='FILLVAL')
+                             drop_meta_labels='FILLVAL',
+                             decode_times=False)
 
     if tag in ['nmax', 'tdisk', 'tlimb']:
         # Add time coordinate from scan_start_time


### PR DESCRIPTION
# Description

Addresses #189

Specifies a default for `decode_times` to maintain current behavior.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Loading data for xarray netCDF instruments

## Test Configuration
* Operating system: Monterrey
* Version number: Python 3.10.9

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
