### PR TITLE
MAINT: update installs for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,4 +19,7 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-   - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.X.X] - 2023-XX-XX
 * Maintenance
   * Implemented unit tests for cleaning warnings
+  * Use pip install for readthedocs
 
 ## [0.0.5] - 2023-06-27
 * New Instruments

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-extras_require
-m2r2
-numpydoc
-pysat
-pysatNASA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ doc = [
   "m2r2",
   "numpydoc",
   "sphinx",
-  "sphinx_rtd_theme"
+  "sphinx_rtd_theme >= 1.2.2"
 ]
 
 [project.urls]


### PR DESCRIPTION
# Description

Use pip install with options so that a separate requirements list under the docs directory is not needed.

Also adds a minimum version to `sphinx_rtd_theme`. Somewhere in the dependency tree, someone updated something which is breaking pip's ability to calculate what the dependencies are. Forcing a minimum version of the rtd theme fixes this (for now).

# Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

via GitHub Actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
