### PR TITLE
STY: use standard init routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Maintenance
   * Implemented unit tests for cleaning warnings
   * Use pip install for readthedocs
-  * Move references and acknowledgements to methods files
+  * Moved references and acknowledgements to methods files
 
 ## [0.0.5] - 2023-06-27
 * New Instruments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Maintenance
   * Implemented unit tests for cleaning warnings
   * Use pip install for readthedocs
+  * Move references and acknowledgements to methods files
 
 ## [0.0.5] - 2023-06-27
 * New Instruments

--- a/pysatNASA/instruments/formosat1_ivm.py
+++ b/pysatNASA/instruments/formosat1_ivm.py
@@ -26,9 +26,9 @@ import datetime as dt
 import functools
 
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import formosat as mm_formosat
 from pysatNASA.instruments.methods import general as mm_nasa
 
 # ----------------------------------------------------------------------------
@@ -47,31 +47,7 @@ _test_dates = {'': {'': dt.datetime(2002, 1, 1)}}
 # ----------------------------------------------------------------------------
 # Instrument methods
 
-
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    """
-    self.acknowledgements = ' '.join(('Data provided through NASA CDAWeb',
-                                      'Key Parameters - Shin-Yi Su',
-                                      '(Institute of Space Science,',
-                                      'National Central University,',
-                                      'Taiwan, R.O.C.)'))
-    self.references = ' '.join(('Yeh, H.C., S.‐Y. Su, Y.C. Yeh, J.M. Wu,',
-                                'R. A. Heelis, and B. J. Holt, Scientific',
-                                'mission of the IPEI payload on board',
-                                'ROCSAT‐1, Terr. Atmos. Ocean. Sci., 9,',
-                                'suppl., 1999a.\n',
-                                'Yeh, H.C., S.‐Y. Su, R.A. Heelis, and',
-                                'J.M. Wu, The ROCSAT‐1 IPEI preliminary',
-                                'results, Vertical ion drift statistics,',
-                                'Terr. Atmos. Ocean. Sci., 10, 805,',
-                                '1999b.'))
-    logger.info(self.acknowledgements)
-
-    return
+init = functools.partial(mm_nasa.init, module=mm_formosat, name=name)
 
 
 # Use default clean

--- a/pysatNASA/instruments/iss_fpmu.py
+++ b/pysatNASA/instruments/iss_fpmu.py
@@ -28,10 +28,10 @@ import datetime as dt
 import functools
 
 from pysat.instruments.methods import general as mm_gen
-from pysat import logger
 
 from pysatNASA.instruments.methods import cdaweb as cdw
 from pysatNASA.instruments.methods import general as mm_nasa
+from pysatNASA.instruments.methods import iss as mm_iss
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -49,34 +49,7 @@ _test_dates = {'': {'': dt.datetime(2017, 10, 1)}}
 # ----------------------------------------------------------------------------
 # Instrument methods
 
-
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    """
-
-    ackn_str = ' '.join(('Data provided through NASA CDAWeb.  Contact',
-                         'Rob.Suggs@nasa.gov for support and use.'))
-    logger.info(ackn_str)
-    self.acknowledgements = ackn_str
-    self.references = ' '.join(('V. N. Coffey et al., "Validation of the',
-                                'Plasma Densities and Temperatures From',
-                                'the ISS Floating Potential Measurement',
-                                'Unit," in IEEE Transactions on Plasma',
-                                'Science, vol. 36, no. 5, pp. 2301-2308,',
-                                'Oct. 2008,',
-                                'doi: 10.1109/TPS.2008.2004271.\n',
-                                'A. Barjatya, C.M. Swenson, D.C.',
-                                'Thompson, and K.H. Wright Jr., Data',
-                                'analysis of the Floating Potential',
-                                'Measurement Unit aboard the',
-                                'International Space Station, Rev. Sci.',
-                                'Instrum. 80, 041301 (2009),',
-                                'https://doi.org/10.1063/1.3116085'))
-
-    return
+init = functools.partial(mm_nasa.init, module=mm_iss, name=name)
 
 
 # Use default clean

--- a/pysatNASA/instruments/methods/__init__.py
+++ b/pysatNASA/instruments/methods/__init__.py
@@ -5,9 +5,11 @@ from pysatNASA.instruments.methods import cdaweb  # noqa F401
 from pysatNASA.instruments.methods import cnofs  # noqa F401
 from pysatNASA.instruments.methods import de2  # noqa F401
 from pysatNASA.instruments.methods import dmsp  # noqa F401
+from pysatNASA.instruments.methods import formosat  # noqa F401
 from pysatNASA.instruments.methods import general  # noqa F401
 from pysatNASA.instruments.methods import gps  # noqa F401
 from pysatNASA.instruments.methods import icon  # noqa F401
+from pysatNASA.instruments.methods import iss  # noqa F401
 from pysatNASA.instruments.methods import jhuapl  # noqa F401
 from pysatNASA.instruments.methods import omni  # noqa F401
 from pysatNASA.instruments.methods import ses14  # noqa F401

--- a/pysatNASA/instruments/methods/formosat.py
+++ b/pysatNASA/instruments/methods/formosat.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""Provides non-instrument specific routines for C/NOFS data."""
+
+ackn_str = ' '.join(('Data provided through NASA CDAWeb Key Parameters -',
+                     'Shin-Yi Su (Institute of Space Science, National Central',
+                     'University, Taiwan, R.O.C.)'))
+refs = {'ivm': ' '.join(('Yeh, H.C., S.‐Y. Su, Y.C. Yeh, J.M. Wu, R. A.',
+                         'Heelis, and B. J. Holt, Scientific mission of the',
+                         'IPEI payload on board ROCSAT‐1, Terr. Atmos. Ocean.',
+                         'Sci., 9, suppl., 1999a.\n',
+                         'Yeh, H.C., S.‐Y. Su, R.A. Heelis, and J.M. Wu, The',
+                         'ROCSAT‐1 IPEI preliminary results, Vertical ion',
+                         'drift statistics, Terr. Atmos. Ocean. Sci., 10, 805,',
+                         '1999b.'))}

--- a/pysatNASA/instruments/methods/iss.py
+++ b/pysatNASA/instruments/methods/iss.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""Provides non-instrument specific routines for C/NOFS data."""
+
+ackn_str = ' '.join(("R.M. Suggs, S.L. Koontz, NASA Johnson Space Center",
+                     "Contact Rob Suggs for support and use.",
+                     "Rob.Suggs@nasa.gov. Please acknowledge the data",
+                     "providers and CDAWeb when using these data."))
+
+refs = {'fpmu': ' '.join(('V. N. Coffey et al., "Validation of the Plasma',
+                          'Densities and Temperatures From the ISS Floating',
+                          'Potential Measurement Unit," in IEEE Transactions',
+                          'on Plasma Science, vol. 36, no. 5, pp. 2301-2308,',
+                          'Oct. 2008, doi: 10.1109/TPS.2008.2004271.',
+                          '\n',
+                          'A. Barjatya, C.M. Swenson, D.C. Thompson, and K.H.',
+                          'Wright Jr., Data analysis of the Floating Potential',
+                          'Measurement Unit aboard the International Space',
+                          'Station, Rev. Sci. Instrum. 80, 041301 (2009),',
+                          'https://doi.org/10.1063/1.3116085',
+                          '\n',
+                          'Debchoudhury, S., Barjatya, A., Minow, J. I.,',
+                          'Coffey, V. N., & Chandler, M. O. (2021).',
+                          'Observations and validation of plasma density,',
+                          'temperature, and O+ abundance from a Langmuir',
+                          'probe onboard the International Space Station.',
+                          'Journal of Geophysical Research: Space',
+                          'Physics, 126, e2021JA029393.',
+                          'https://doi.org/10.1029/2021JA029393'))
+        }

--- a/pysatNASA/instruments/methods/omni.py
+++ b/pysatNASA/instruments/methods/omni.py
@@ -9,6 +9,17 @@ from scipy import stats
 import pysat
 
 
+ackn_str = ' '.join(('For full acknowledgement info, please see:',
+                     'https://omniweb.gsfc.nasa.gov/html/citing.html'))
+
+refs = {'hro': ' '.join(('J.H. King and N.E. Papitashvili, Solar',
+                         'wind spatial scales in and comparisons',
+                         'of hourly Wind and ACE plasma and',
+                         'magnetic field data, J. Geophys. Res.,',
+                         'Vol. 110, No. A2, A02209,',
+                         '10.1029/2004JA010649.'))}
+
+
 def time_shift_to_magnetic_poles(inst):
     """Shift OMNI times to intersection with the magnetic pole.
 

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -44,7 +44,6 @@ import numpy as np
 import pandas as pds
 import warnings
 
-import pysat
 from pysat.instruments.methods import general as mm_gen
 
 from pysatNASA.instruments.methods import cdaweb as cdw

--- a/pysatNASA/instruments/omni_hro.py
+++ b/pysatNASA/instruments/omni_hro.py
@@ -48,6 +48,7 @@ import pysat
 from pysat.instruments.methods import general as mm_gen
 
 from pysatNASA.instruments.methods import cdaweb as cdw
+from pysatNASA.instruments.methods import general as mm_nasa
 from pysatNASA.instruments.methods import omni as mm_omni
 
 # ----------------------------------------------------------------------------
@@ -68,25 +69,7 @@ _test_dates = {'': {'1min': dt.datetime(2009, 1, 1),
 # ----------------------------------------------------------------------------
 # Instrument methods
 
-
-def init(self):
-    """Initialize the Instrument object with instrument specific values.
-
-    Runs once upon instantiation.
-
-    """
-
-    ackn_str = ''.join(('For full acknowledgement info, please see: ',
-                        'https://omniweb.gsfc.nasa.gov/html/citing.html'))
-    self.acknowledgements = ackn_str
-    self.references = ' '.join(('J.H. King and N.E. Papitashvili, Solar',
-                                'wind spatial scales in and comparisons',
-                                'of hourly Wind and ACE plasma and',
-                                'magnetic field data, J. Geophys. Res.,',
-                                'Vol. 110, No. A2, A02209,',
-                                '10.1029/2004JA010649.'))
-    pysat.logger.info(ackn_str)
-    return
+init = functools.partial(mm_nasa.init, module=mm_omni, name=name)
 
 
 def clean(self):


### PR DESCRIPTION
# Description

Addresses #121

- Moves acknowledgement string and references to methods files for all (non-deprecated) instruments.
- Uses standard `init` routine for other methods
- Updates references for new calibration of ISS FPMU data

# Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Instantiating instruments and printing refs:
```
import pysat
fpmu = pysat.Instrument('iss', 'fpmu')
print(fpmu.references)
```
**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.9.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
