### PR TITLE
BUG: cleaning routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * MAVEN mag
   * MAVEN SEP
   * MAVEN in situ
+* Bug Fixes
+  * Fix general clean routine to skip transformation matrices
 * Maintenance
   * Implemented unit tests for cleaning warnings
   * Use pip install for readthedocs

--- a/pysatNASA/instruments/methods/general.py
+++ b/pysatNASA/instruments/methods/general.py
@@ -69,7 +69,12 @@ def clean(self):
     for key in self.variables:
         # Check for symmetric dims
         # Indicates transformation matrix, xarray cannot broadcast
-        unique_dims = len(self[key].dims) == len(np.unique(self[key].dims))
+        if self.pands_format:
+            # True by default
+            unique_dims = True
+        else:
+            # Check for multiple dims
+            unique_dims = len(self[key].dims) == len(np.unique(self[key].dims))
         # Skip over the coordinates when cleaning
         if key not in coords and unique_dims:
             fill = self.meta[key, self.meta.labels.fill_val]

--- a/pysatNASA/instruments/methods/general.py
+++ b/pysatNASA/instruments/methods/general.py
@@ -67,8 +67,10 @@ def clean(self):
         coords = [key for key in self.data.coords.keys()]
 
     for key in self.variables:
+        # Check for symmetric dims
+        unique_dims = len(self[key].dims) == len(np.unique(self[key].dims))
         # Skip over the coordinates when cleaning
-        if key not in coords:
+        if key not in coords and unique_dims:
             fill = self.meta[key, self.meta.labels.fill_val]
 
             # Replace fill with nan

--- a/pysatNASA/instruments/methods/general.py
+++ b/pysatNASA/instruments/methods/general.py
@@ -69,7 +69,7 @@ def clean(self):
     for key in self.variables:
         # Check for symmetric dims
         # Indicates transformation matrix, xarray cannot broadcast
-        if self.pands_format:
+        if self.pandas_format:
             # True by default
             unique_dims = True
         else:

--- a/pysatNASA/instruments/methods/general.py
+++ b/pysatNASA/instruments/methods/general.py
@@ -68,6 +68,7 @@ def clean(self):
 
     for key in self.variables:
         # Check for symmetric dims
+        # Indicates transformation matrix, xarray cannot broadcast
         unique_dims = len(self[key].dims) == len(np.unique(self[key].dims))
         # Skip over the coordinates when cleaning
         if key not in coords and unique_dims:


### PR DESCRIPTION
# Description

The maven insitu data is having an issue with the general cleaning routine. This is because it includes transformation matrics that have symmetric dimensions, ie ('time', 'compno_3', 'compno_3'). `xarray` doesn't like this. Since it doesn't make sense to clean the transformation matrices (similar to coords), we place a check in the clean routine to skip over these.

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

loading maven insitu data

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.9.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
