### PR TITLE
Improved init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.X.X] - 2023-XX-XX
 * Bug Fix
   * New window needs to be integer for calculate_imf_steadiness
+  * Fixed version import
 * Documentation
   * Added example of how to export data for archival
 * Maintenance

--- a/pysatNASA/__init__.py
+++ b/pysatNASA/__init__.py
@@ -6,15 +6,12 @@ portal.
 
 """
 
-import importlib
-import importlib_metadata
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata
 
 from pysatNASA import constellations  # noqa F401
 from pysatNASA import instruments  # noqa F401
 
-# set version
-try:
-    __version__ = importlib.metadata.version('pysatNASA')
-except AttributeError:
-    # Python 3.6 requires a different version
-    __version__ = importlib_metadata.version('pysatNASA')
+__version__ = metadata.version('pysatNASA')


### PR DESCRIPTION
# Description

On another project, I found out that `metadata` needs to be imported from `importlib` and can't be reliably called as a submodule by importing `importlib`.  Added fixes here.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`python -c "import pysatNASA; print(pysatNASA.__version__)"`

But sometimes this also works without the fix 🐞 

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
