### PR TITLE
MAINT: cnofs vefi magnetometer data

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,5 +73,6 @@ jobs:
 
     - name: Publish results to coveralls
       env:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_SERVICE_JOB_ID: ${{ github.run_id }}
       run: coveralls --rcfile=pyproject.toml --service=github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,5 +73,5 @@ jobs:
 
     - name: Publish results to coveralls
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
       run: coveralls --rcfile=pyproject.toml --service=github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,5 +74,5 @@ jobs:
     - name: Publish results to coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_SERVICE_JOB_ID: ${{ github.run_id }}
+        COVERALLS_SERVICE_JOB_ID: ${{ github.job }}
       run: coveralls --rcfile=pyproject.toml --service=github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Use pip install for readthedocs
   * Moved references and acknowledgements to methods files
   * Added tests for OMNI HRO routines
+  * Use standard clean routine for C/NOFS VEFI mag data
 
 ## [0.0.5] - 2023-06-27
 * New Instruments

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -62,7 +62,6 @@ doi:10.1016/j.jastp.2004.07.030.
 
 import datetime as dt
 import functools
-import numpy as np
 
 from pysat.instruments.methods import general as mm_gen
 
@@ -91,21 +90,8 @@ _test_dates = {'': {'dc_b': dt.datetime(2009, 1, 1)}}
 init = functools.partial(mm_nasa.init, module=mm_cnofs, name=name)
 
 
-def clean(self):
-    """Clean VEFI data to the specified level.
-
-    Note
-    ----
-    'dusty' or 'clean' removes data when interpolation flag is set to 1
-    'dirty' is the same as 'none'
-
-    """
-
-    if (self.clean_level == 'dusty') | (self.clean_level == 'clean'):
-        idx, = np.where(self['B_flag'] == 0)
-        self.data = self[idx, :]
-
-    return
+# Use default clean
+clean = mm_nasa.clean
 
 
 # ----------------------------------------------------------------------------

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -62,6 +62,7 @@ doi:10.1016/j.jastp.2004.07.030.
 
 import datetime as dt
 import functools
+import numpy as np
 
 from pysat.instruments.methods import general as mm_gen
 
@@ -90,8 +91,24 @@ _test_dates = {'': {'dc_b': dt.datetime(2009, 1, 1)}}
 init = functools.partial(mm_nasa.init, module=mm_cnofs, name=name)
 
 
-# Use default clean
-clean = mm_nasa.clean
+def clean(self):
+    """Clean VEFI data to the specified level.
+
+    Note
+    ----
+    'dusty' or 'clean' removes data when interpolation flag is set to 1
+    'dirty' is the same as 'none'
+
+    """
+
+    if 'B_flag' in self.variables:
+        if (self.clean_level == 'dusty') | (self.clean_level == 'clean'):
+            idx, = np.where(self['B_flag'] == 0)
+            self.data = self[idx, :]
+    else:
+        mm_nasa.clean(self)
+
+    return
 
 
 # ----------------------------------------------------------------------------

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -101,12 +101,13 @@ def clean(self):
 
     """
 
+    mm_nasa.clean(self)
+
+    # Apply legacy clean routine for version 5 data
     if 'B_flag' in self.variables:
         if (self.clean_level == 'dusty') | (self.clean_level == 'clean'):
             idx, = np.where(self['B_flag'] == 0)
             self.data = self[idx, :]
-    else:
-        mm_nasa.clean(self)
 
     return
 


### PR DESCRIPTION
# Description

C/NOFS VEFI `dc_b` data has an updated dataset (v6) uploaded to SPDF as of 7 Nov 2023. This does not use the old error flag, but uses the standard fill value demarked in metadata. Since 'B_flag' is no longer present, unit tests will fail unless this is fixed.

Updates to use the standard cleaning routine

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import datetime as dt
import pysat

# Get latest data
vefi = pysat.Instrument('cnofs', 'vefi', tag='dc_b')
vefi.download(dt.datetime(2009, 1, 1))

# Load with clean routine
vefi.load(2009, 1)
print(vefi.meta['B_north'].fill)

# Load without cleaning
vefi = pysat.Instrument('cnofs', 'vefi', tag='dc_b', clean_level='none')
vefi.load(2009, 1)
print(vefi.meta['B_north'].fill)
```
Verify that for the clean routine the fill value is NaN, and for the non-clean load the fill value is -1e+31

**Test Configuration**:
* Operating system: Ventura
* Version number: Python 3.10.9

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
