### PR TITLE
TST: add codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,7 @@ jobs:
     - uses: codecov/codecov-action@v3
 
     - name: Publish results to coveralls
+      if: ${{ matrix.os != 'macos-latest'}}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       uses: coverallsapp/github-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,5 @@ jobs:
     - name: Publish results to coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_SERVICE_JOB_ID: ${{ github.job }}
-        COVERALLS_SERVICE_NUMBER: $ {{ github.run_id }}
       uses: coverallsapp/github-action@v2
       continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
         mkdir pysatData
         python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
 
+  test:
     - name: Test PEP8 compliance
       run: flake8 . --count --select=D,E,F,H,W --show-source --statistics
 
@@ -77,3 +78,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       uses: coverallsapp/github-action@v2
+      with:
+        parallel: true
+        flag-name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,6 @@ jobs:
         mkdir pysatData
         python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
 
-  test:
     - name: Test PEP8 compliance
       run: flake8 . --count --select=D,E,F,H,W --show-source --statistics
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,5 +78,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_JOB_ID: ${{ github.job }}
         COVERALLS_SERVICE_NUMBER: $ {{ github.run_id }}
-      run: coveralls --rcfile=pyproject.toml --service=github
+      uses: coverallsapp/github-action@v2
       continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,9 +71,12 @@ jobs:
     - name: Test with pytest
       run: pytest
 
+    - uses: codecov/codecov-action@v3
+
     - name: Publish results to coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_JOB_ID: ${{ github.job }}
         COVERALLS_SERVICE_NUMBER: $ {{ github.run_id }}
       run: coveralls --rcfile=pyproject.toml --service=github
+      continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,4 +77,3 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       uses: coverallsapp/github-action@v2
-      continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 # pysatNASA: pysat support for NASA Space Science instruments
 [![PyPI Package latest release](https://img.shields.io/pypi/v/pysatNASA.svg)](https://pypi.python.org/pypi/pysatNASA)
 [![Build Status](https://github.com/github/docs/actions/workflows/main.yml/badge.svg)](https://github.com/github/docs/actions/workflows/main.yml/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/pysat/pysatNASA/badge.svg?branch=main)](https://coveralls.io/github/pysat/pysatNASA?branch=main)
+[![Coveralls Status](https://coveralls.io/repos/github/pysat/pysatNASA/badge.svg?branch=main)](https://coveralls.io/github/pysat/pysatNASA?branch=main)
+[![Codecov Status](https://codecov.io/gh/pysat/pysatNASA/branch/main/graph/badge.svg?branch=main)](https://codecov.io/gh/pysat/pysatNASA)
 
 [![Documentation Status](https://readthedocs.org/projects/pysatnasa/badge/?version=latest)](https://pysatnasa.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/287387638.svg)](https://zenodo.org/badge/latestdoi/287387638)


### PR DESCRIPTION
Experiment with codecov as a replacement for coveralls. Previously used successfully with sami2py.

Includes 'continue-on-error' for coveralls. If coveralls fails to run, the workflow will still complete successfully.

Coverage available at: https://app.codecov.io/github/pysat/pysatNASA/tree/codecov?displayType=list