### PR TITLE
BUG/MAINT: cdaweb downloads, ICON IVM-B tests, new flag to skip new tests

### DIFF
--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -31,10 +31,8 @@ jobs:
     - name: Install pysat RC
       run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysat
 
-    - name: Install standard dependencies
-      run: |
-        pip install -r requirements.txt
-        pip install -r test_requirements.txt
+    - name: Install with standard dependencies
+      run: pip install .[test]
 
     - name: Set up pysat
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * New window needs to be integer for calculate_imf_steadiness
   * Fixed version import
   * Fixed a bug when data fails to load for CDF pandas objects
+  * Fixed a bug where cdas_download may drop the requested end date file
 * Documentation
   * Added example of how to export data for archival
   * Updated documentation refs
@@ -28,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added tests for OMNI HRO routines
   * Use standard clean routine for C/NOFS VEFI mag data
   * Added version cap for sphinx_rtd_theme
+  * Include standard tests for ICON IVM-B
 
 ## [0.0.5] - 2023-06-27
 * New Instruments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ Source = "https://github.com/pysat/pysatNASA"
 omit = ["*/instruments/templates/"]
 
 [tool.pytest.ini_options]
-addopts = "-vs --cov=pysatNASA"
+addopts = "--cov=pysatNASA"
 markers = [
   "all_inst",
   "download",

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -80,7 +80,7 @@ inst_ids = {'': ['']}
 
 _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 # TODO(#222): Remove when compliant with multi-day load tests
-_test_new_tests = {'': {'': False}}
+_new_tests = {'': {'': False}}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatNASA/instruments/cnofs_plp.py
+++ b/pysatNASA/instruments/cnofs_plp.py
@@ -79,6 +79,8 @@ inst_ids = {'': ['']}
 # Instrument test attributes
 
 _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
+# TODO(#222): Remove when compliant with multi-day load tests
+_test_new_tests = {'': {'': False}}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -66,7 +66,7 @@ pandas_format = False
 
 _test_dates = {'': {'': dt.datetime(2020, 1, 1)}}
 # TODO(#218, #222): Remove when compliant with multi-day load tests
-_test_new_tests = {'': {'': False}}
+_new_tests = {'': {'': False}}
 _test_load_opt = {'': {'': {'keep_original_names': True}}}
 
 # ----------------------------------------------------------------------------

--- a/pysatNASA/instruments/icon_euv.py
+++ b/pysatNASA/instruments/icon_euv.py
@@ -65,6 +65,8 @@ pandas_format = False
 # Instrument test attributes
 
 _test_dates = {'': {'': dt.datetime(2020, 1, 1)}}
+# TODO(#218, #222): Remove when compliant with multi-day load tests
+_test_new_tests = {'': {'': False}}
 _test_load_opt = {'': {'': {'keep_original_names': True}}}
 
 # ----------------------------------------------------------------------------

--- a/pysatNASA/instruments/icon_ivm.py
+++ b/pysatNASA/instruments/icon_ivm.py
@@ -68,9 +68,7 @@ multi_file_day = True
 # Instrument test attributes
 
 _test_dates = {'a': {'': dt.datetime(2020, 1, 1)},
-               'b': {'': dt.datetime(2020, 1, 1)}}  # IVM-B not yet engaged
-_test_download = {'b': {kk: False for kk in tags.keys()}}
-_password_req = {'b': {kk: True for kk in tags.keys()}}
+               'b': {'': dt.datetime(2021, 6, 15)}}
 _test_load_opt = {jj: {'': {'keep_original_names': True}}
                   for jj in inst_ids.keys()}
 

--- a/pysatNASA/instruments/maven_insitu_kp.py
+++ b/pysatNASA/instruments/maven_insitu_kp.py
@@ -52,6 +52,8 @@ pandas_format = False
 # Instrument test attributes
 
 _test_dates = {'': {'': dt.datetime(2020, 1, 1)}}
+# TODO(#218, #222): Remove when compliant with multi-day load tests
+_test_new_tests = {'': {'': False}}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatNASA/instruments/maven_insitu_kp.py
+++ b/pysatNASA/instruments/maven_insitu_kp.py
@@ -53,7 +53,7 @@ pandas_format = False
 
 _test_dates = {'': {'': dt.datetime(2020, 1, 1)}}
 # TODO(#218, #222): Remove when compliant with multi-day load tests
-_test_new_tests = {'': {'': False}}
+_new_tests = {'': {'': False}}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatNASA/instruments/methods/_cdf.py
+++ b/pysatNASA/instruments/methods/_cdf.py
@@ -437,13 +437,14 @@ class CDF(object):
         index = None
         for varname, df in cdata.items():
             if varname not in ('Epoch', 'DATE'):
-                if type(df) == pds.Series:
+                if isinstance(df, pds.Series):
                     data[varname] = df
 
                     # CDF data Series are saved using a mix of Range and
                     # Datetime Indexes. This requires that the user specify
                     # the desired index when creating a DataFrame
-                    if type(df.index) == pds.DatetimeIndex and index is None:
+                    if isinstance(df.index,
+                                  pds.DatetimeIndex) and index is None:
                         index = df.index
 
         if index is None:

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -964,9 +964,12 @@ def cdas_list_remote_files(tag='', inst_id='', start=None, stop=None,
     elif start == stop:
         stop = start + dt.timedelta(days=1)
 
-    if isinstance(start, pds._libs.tslibs.timestamps.Timestamp):
-        start = start.tz_localize('utc')
-        stop = stop.tz_localize('utc')
+    # Ensure that valid date types are used.
+    start = pysat.utils.time.filter_datetime_input(start)
+    stop = pysat.utils.time.filter_datetime_input(stop)
+
+    # CDAS WS needs a time for the stop date.
+    stop += dt.timedelta(seconds=86399)
 
     og_files = cdas.get_original_files(dataset=dataset, start=start, end=stop)
 

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -89,8 +89,12 @@ multi_file_day = True
 _test_dates = {iid: {tag: dt.datetime(2005, 6, 28) for tag in inst_ids[iid]}
                for iid in inst_ids.keys()}
 _test_load_opt = {iid: {tag: {'combine_times': True}
-                        for tag in inst_ids[iid]} for iid in ['high_res',
-                                                              'low_res']}
+                        for tag in inst_ids[iid]}
+                  for iid in ['high_res', 'low_res']}
+# TODO(#218): Remove when compliant with multi-day load tests
+_test_new_tests = {iid: {tag: False
+                         for tag in inst_ids[iid]}
+                   for iid in ['high_res', 'low_res']}
 _clean_warn = {inst_id: {tag: mm_nasa.clean_warnings
                          for tag in inst_ids[inst_id]}
                for inst_id in inst_ids.keys()}

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -92,9 +92,8 @@ _test_load_opt = {iid: {tag: {'combine_times': True}
                         for tag in inst_ids[iid]}
                   for iid in ['high_res', 'low_res']}
 # TODO(#218): Remove when compliant with multi-day load tests
-_new_tests = {iid: {tag: False
-                         for tag in inst_ids[iid]}
-                   for iid in ['high_res', 'low_res']}
+_new_tests = {iid: {tag: False for tag in inst_ids[iid]}
+              for iid in ['high_res', 'low_res']}
 _clean_warn = {inst_id: {tag: mm_nasa.clean_warnings
                          for tag in inst_ids[inst_id]}
                for inst_id in inst_ids.keys()}

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -92,7 +92,7 @@ _test_load_opt = {iid: {tag: {'combine_times': True}
                         for tag in inst_ids[iid]}
                   for iid in ['high_res', 'low_res']}
 # TODO(#218): Remove when compliant with multi-day load tests
-_test_new_tests = {iid: {tag: False
+_new_tests = {iid: {tag: False
                          for tag in inst_ids[iid]}
                    for iid in ['high_res', 'low_res']}
 _clean_warn = {inst_id: {tag: mm_nasa.clean_warnings

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -18,8 +18,6 @@ inst_id : str
 
 Note
 ----
-Note on Temperature Errors: https://saber.gats-inc.com/temp_errors.php
-
 SABER "Rules of the Road" for DATA USE
 Users of SABER data are asked to respect the following guidelines
 
@@ -44,6 +42,8 @@ Warnings
 - No cleaning routine
 
 """
+
+# Note on Temperature Errors: https://saber.gats-inc.com/temp_errors.php
 
 import datetime as dt
 import functools

--- a/pysatNASA/instruments/timed_saber.py
+++ b/pysatNASA/instruments/timed_saber.py
@@ -18,6 +18,8 @@ inst_id : str
 
 Note
 ----
+Note on Temperature Errors: https://saber.gats-inc.com/temp_errors.php
+
 SABER "Rules of the Road" for DATA USE
 Users of SABER data are asked to respect the following guidelines
 
@@ -42,8 +44,6 @@ Warnings
 - No cleaning routine
 
 """
-
-# Note on Temperature Errors: https://saber.gats-inc.com/temp_errors.php
 
 import datetime as dt
 import functools


### PR DESCRIPTION
# Description

Addresses #218 (partial)

Fixes a major issue where `cdasws` ignores the end date for download requests if no data is present at 00:00:00 on the end date. This fixes most of the items in #218.

Adds testing flags for upcoming pysat pull to ignore "new" tests for now while we update the ecosystem. Usage of flags includes TODO statements linked to the relevant issue.

Turns on tests for ICON IVM-B now that some data is public for that.

# Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

pytest using the `enh/test_triage` branch of `pysat`

**Test Configuration**:
* Operating system: Ventura 3.6.1
* Version number: Python 3.10.9
* `pysat` enh/test_triage branch

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
