### PR TITLE
SSUSI bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * MAVEN SEP
   * MAVEN in situ key parameters
   * REACH Dosimeter
-  * DMSP SSUSI SDR-disk data
+  * DMSP SSUSI SDR-disk and SDR2-disk data
 * New Features
   * Allow files to be unzipped after download
-  * Added custom `concat_data` method to TIMED-GUVI data
+  * Added custom `concat_data` method to JHUAPL methods, for TIMED-GUVI and
+    DMSP-SSUSI data
   * Added cleaning to TIMED-GUVI SDR imaging data
 * Bug Fixes
   * Fix general clean routine to skip transformation matrices

--- a/pysatNASA/instruments/dmsp_ssusi.py
+++ b/pysatNASA/instruments/dmsp_ssusi.py
@@ -89,7 +89,8 @@ _clean_warn = {inst_id: {tag: mm_nasa.clean_warnings
                          if tag not in ['sdr-disk', 'sdr2-disk']}
                for inst_id in inst_ids.keys()}
 # TODO(#218): Remove when compliant with multi-day load tests
-_new_tests = {inst_id: {'sdr-disk': False} for inst_id in inst_ids.keys()}
+_new_tests = {inst_id: {'sdr-disk': False, 'sdr2-dist': False}
+              for inst_id in inst_ids.keys()}
 _clean_warn = {inst_id: {tag: mm_nasa.clean_warnings
                          for tag in inst_ids[inst_id]
                          if tag not in ['sdr-disk', 'sdr2-disk']}

--- a/pysatNASA/instruments/dmsp_ssusi.py
+++ b/pysatNASA/instruments/dmsp_ssusi.py
@@ -118,6 +118,38 @@ def clean(self):
     return
 
 
+def concat_data(self, new_data, combine_times=False, **kwargs):
+    """Concatonate data to self.data for DMSP SSUSI data.
+
+    Parameters
+    ----------
+    new_data : xarray.Dataset or list of such objects
+        New data objects to be concatonated
+    combine_times : bool
+        For SDR data, optionally combine the different datetime coordinates
+        into a single time coordinate (default=False)
+    **kwargs : dict
+        Optional keyword arguments passed to xr.concat
+
+    Note
+    ----
+    For xarray, `dim=Instrument.index.name` is passed along to xarray.concat
+    except if the user includes a value for dim as a keyword argument.
+
+    """
+    # Establish the time dimensions by data type
+    time_dims = [self.index.name]
+
+    if self.tag in ['sdr-disk', 'sdr2-dist']:
+        time_dims.append('time_auroral')
+
+    # Concatonate using the appropriate method for the number of time
+    # dimensions
+    jhuapl.concat_data(self, time_dims, new_data, combine_times=combine_times,
+                       **kwargs)
+    return
+
+
 # ----------------------------------------------------------------------------
 # Instrument functions
 #

--- a/pysatNASA/instruments/dmsp_ssusi.py
+++ b/pysatNASA/instruments/dmsp_ssusi.py
@@ -88,6 +88,12 @@ _clean_warn = {inst_id: {tag: mm_nasa.clean_warnings
                          for tag in inst_ids[inst_id]
                          if tag not in ['sdr-disk', 'sdr2-disk']}
                for inst_id in inst_ids.keys()}
+# TODO(#218): Remove when compliant with multi-day load tests
+_new_tests = {inst_id: {'sdr-disk': False} for inst_id in inst_ids.keys()}
+_clean_warn = {inst_id: {tag: mm_nasa.clean_warnings
+                         for tag in inst_ids[inst_id]
+                         if tag not in ['sdr-disk', 'sdr2-disk']}
+               for inst_id in inst_ids.keys()}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatNASA/instruments/timed_guvi.py
+++ b/pysatNASA/instruments/timed_guvi.py
@@ -60,7 +60,6 @@ Example
 
 import datetime as dt
 import functools
-import xarray as xr
 
 import pysat
 from pysat.instruments.methods import general as mm_gen
@@ -158,51 +157,8 @@ def concat_data(self, new_data, combine_times=False, **kwargs):
 
     # Concatonate using the appropriate method for the number of time
     # dimensions
-    if len(time_dims) == 1:
-        # There is only one time dimensions, but other dimensions may
-        # need to be adjusted
-        new_data = pysat.utils.coords.expand_xarray_dims(
-            new_data, self.meta, exclude_dims=time_dims)
-
-        # Combine the data
-        self.data = xr.combine_by_coords(new_data, **kwargs)
-    else:
-        inners = None
-        for ndata in new_data:
-            # Separate into inner datasets
-            inner_keys = {dim: [key for key in ndata.keys()
-                                if dim in ndata[key].dims] for dim in time_dims}
-            inner_dat = {dim: ndata.get(inner_keys[dim]) for dim in time_dims}
-
-            # Add 'single_var's into 'time' dataset to keep track
-            sv_keys = [val.name for val in ndata.values()
-                       if 'single_var' in val.dims]
-            singlevar_set = ndata.get(sv_keys)
-            inner_dat[self.index.name] = xr.merge([inner_dat[self.index.name],
-                                                   singlevar_set])
-
-            # Concatenate along desired dimension with previous data
-            if inners is None:
-                # No previous data, assign the data separated by dimension
-                inners = dict(inner_dat)
-            else:
-                # Concatenate with existing data
-                inners = {dim: xr.concat([inners[dim], inner_dat[dim]],
-                                         dim=dim) for dim in time_dims}
-
-        # Combine all time dimensions
-        if inners is not None:
-            if combine_times:
-                data_list = pysat.utils.coords.expand_xarray_dims(
-                    [inners[dim] if dim == self.index.name else
-                     inners[dim].rename_dims({dim: self.index.name})
-                     for dim in time_dims if len(inners[dim].dims) > 0],
-                    self.meta, dims_equal=False)
-            else:
-                data_list = [inners[dim] for dim in time_dims]
-
-            # Combine all the data, indexing along time
-            self.data = xr.merge(data_list)
+    jhuapl.concat_data(self, time_dims, new_data, combine_times=combine_times,
+                       **kwargs)
     return
 
 


### PR DESCRIPTION
# Description

Addresses an issue found when loading subsequent days of DMSP SSUSI SDR-Disk data, which caused a memory failure.  Fixed by adding a custom `concat_data` method.  This shares many lines of code with TIMED GUVI, so the comment elements were moved to `pysatNASA.instruments.methods.jhuapl`.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import datetime as dt
import pysat

ssusi = pysat.Instrument('dmsp', 'ssusi', 'sdr-disk', 'f18')
stime = dt.datetime(2010, 4, 14)

ssusi.load(date=stime)  # Will be fine

stime += dt.timedelta(days=1)
ssusi.load(date=stime)  # Will fail and potentially crash your computer without fix
```

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant: develop branch of pysat

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
