### PR TITLE
BUG: Revert integration to GitHub service for coveralls on MacOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,17 +90,13 @@ jobs:
       run: |
         curl -L https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-windows.exe -o coveralls.exe
         ./coveralls.exe report --parallel --repo-token=${{ secrets.COVERALLS_REPO_TOKEN }} --build-number ${{ github.run_number }}
-    - name: Coveralls Parallel (MacOS)
+    - name: Publish results to coveralls (MacOS)
       if: startsWith(matrix.os, 'macos')
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_PARALLEL: true
       run: |
-        brew tap coverallsapp/coveralls
-        brew install coveralls
-        ls -lh .coverage
-        ls -lh coverage.xml
-        coveralls report coverage.xml --format=cobertura --verbose --parallel --repo-token=${{ secrets.COVERALLS_REPO_TOKEN }} --build-number ${{ github.run_number }} --debug --dry-run
+        coveralls --rcfile=pyproject.toml --service=github
   finish:
     name: Finish Coverage Analysis
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
       run: flake8 . --count --exit-zero --max-complexity=10 --statistics
 
     - name: Test with pytest
-      run: pytest
+      run: pytest -v --showlocals
 
     - name: Coveralls Parallel (Ubuntu)
       if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,23 +52,19 @@ jobs:
         python setup.py develop
         cd ../pysatNASA
         pip install .
-
     - name: Install NEP29 dependencies
       if: ${{ matrix.test_config == 'NEP29'}}
       run: |
         pip install numpy==${{ matrix.numpy_ver }}
         pip install --upgrade-strategy only-if-needed .[test]
-
     - name: Install standard dependencies
       if: ${{ matrix.test_config == 'latest'}}
       run: |
         pip install .[test]
-
     - name: Set up pysat
       run: |
         mkdir pysatData
         python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
-
     - name: Test PEP8 compliance
       run: flake8 . --count --select=D,E,F,H,W --show-source --statistics
 
@@ -76,7 +72,7 @@ jobs:
       run: flake8 . --count --exit-zero --max-complexity=10 --statistics
 
     - name: Test with pytest
-      run: pytest -v --showlocals
+      run: pytest
 
     - name: Coveralls Parallel (Ubuntu)
       if: startsWith(matrix.os, 'ubuntu')
@@ -86,7 +82,6 @@ jobs:
       run: |
         curl -sL https://coveralls.io/coveralls-linux.tar.gz | tar -xz
         ./coveralls report --parallel --repo-token=${{ secrets.COVERALLS_REPO_TOKEN }} --build-number ${{ github.run_number }}
-
     - name: Coveralls Parallel (Windows)
       if: startsWith(matrix.os, 'windows')
       env:
@@ -95,20 +90,17 @@ jobs:
       run: |
         curl -L https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-windows.exe -o coveralls.exe
         ./coveralls.exe report --parallel --repo-token=${{ secrets.COVERALLS_REPO_TOKEN }} --build-number ${{ github.run_number }}
-
-    - name: Install Coveralls on MacOS
-      if: startswith(matrix.os, 'macos')
-      run: |
-        pip install coveralls
-
     - name: Coveralls Parallel (MacOS)
       if: startsWith(matrix.os, 'macos')
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_PARALLEL: true
       run: |
+        brew tap coverallsapp/coveralls --quiet
+        brew install coveralls --quiet
+        ls -lh .coverage
+        ls -lh coverage.xml
         coveralls report coverage.xml --format=cobertura --verbose --parallel --repo-token=${{ secrets.COVERALLS_REPO_TOKEN }} --build-number ${{ github.run_number }} --debug --dry-run
-
   finish:
     name: Finish Coverage Analysis
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,8 +96,8 @@ jobs:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_PARALLEL: true
       run: |
-        brew tap coverallsapp/coveralls --quiet
-        brew install coveralls --quiet
+        brew tap coverallsapp/coveralls
+        brew install coveralls
         ls -lh .coverage
         ls -lh coverage.xml
         coveralls report coverage.xml --format=cobertura --verbose --parallel --repo-token=${{ secrets.COVERALLS_REPO_TOKEN }} --build-number ${{ github.run_number }} --debug --dry-run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,16 +96,17 @@ jobs:
         curl -L https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-windows.exe -o coveralls.exe
         ./coveralls.exe report --parallel --repo-token=${{ secrets.COVERALLS_REPO_TOKEN }} --build-number ${{ github.run_number }}
 
+    - name: Install Coveralls on MacOS
+      if: startswith(matrix.os, 'macos')
+      run: |
+        pip install coveralls
+
     - name: Coveralls Parallel (MacOS)
       if: startsWith(matrix.os, 'macos')
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_PARALLEL: true
       run: |
-        brew tap coverallsapp/coveralls --quiet
-        brew install coveralls --quiet
-        ls -lh .coverage
-        ls -lh coverage.xml
         coveralls report coverage.xml --format=cobertura --verbose --parallel --repo-token=${{ secrets.COVERALLS_REPO_TOKEN }} --build-number ${{ github.run_number }} --debug --dry-run
 
   finish:

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -50,6 +50,11 @@
       {
         "name": "Spence, Carey",
         "orcid": "0000-0001-8340-5625"
+      },
+      {
+        "affiliation": "Universities Space Research Association, Goddard Space Flight Center",
+        "name": "Govada, Aadarsh",
+        "orcid": "0009-0004-7873-5899"
       }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added example of how to export data for archival
   * Updated documentation refs
   * Add keywords to zenodo
+  * Fixed broken links
 * Deprecations
   * Deprecated '' tag for de2_vefi module, support moved to de2_vefimagb
 * Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Allow graceful failure with no files in jhuapl load functions
   * New window needs to be integer for calculate_imf_steadiness
   * Fixed a bug where cdas_download may drop the requested end date file
+  * Reverted the coveralls integration to the GitHub service for MacOS runs
 * Documentation
   * Added example of how to export data for archival
   * Updated documentation refs

--- a/pysatNASA/instruments/cnofs_vefi.py
+++ b/pysatNASA/instruments/cnofs_vefi.py
@@ -23,9 +23,10 @@ sec with a range of .. 45,000 nT.  Its primary objective on the CNOFS
 spacecraft is to enable an accurate V x B measurement along the spacecraft
 trajectory.  In order to provide an in-flight calibration of the magnetic field
 data, we compare the most recent POMME model (the POtsdam Magnetic Model of the
-Earth, https://geomag.us/models/pomme5.html) with the actual magnetometer
-measurements to help determine a set of calibration parameters for the gains,
-offsets, and non-orthogonality matrix of the sensor axes.  The calibrated
+Earth, https://geomag.colorado.edu/pomme-5-magnetic-model-of-the-earth.html)
+with the actual magnetometer measurements to help determine a set of calibration
+parameters for the gains, offsets, and non-orthogonality matrix of the sensor
+axes.  The calibrated
 magnetic field measurements are provided in the data file here. The VEFI
 magnetic field data file currently contains the following variables:
 B_north   Magnetic field in the north direction

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
-cdasws
+cdasws<=1.8.2
 cdflib>=0.4.4
 lxml
 netCDF4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
-cdasws<=1.8.2
+cdasws
 cdflib>=0.4.4
 lxml
 netCDF4


### PR DESCRIPTION
# Description

Addresses #232

Coveralls was not producing a report for MacOS using the coverallsapp integration. The coveralls integration has been switched to the GitHub service in the case of MacOS runs. 

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* Operating system: GitHub Actions MacOS
* Version number: Python 3.11 and Python 3.12


# Checklist:

- [ ] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
