### PR TITLE
Empty return without remote files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Allow graceful failure with no files in jhuapl load functions
   * New window needs to be integer for calculate_imf_steadiness
   * Fixed a bug where cdas_download may drop the requested end date file
+  * Fixed a bug where cdas_list_remote_files errored without remote data
 * Documentation
   * Added example of how to export data for archival
   * Updated documentation refs

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -981,7 +981,9 @@ def cdas_list_remote_files(tag='', inst_id='', start=None, stop=None,
 
     og_files = cdas.get_original_files(dataset=dataset, start=start, end=stop)
 
-    if series_out:
+    if og_files[1] is None:
+        file_list = pds.Series(dtype=str) if series_out else []
+    elif series_out:
         name_list = [os.path.basename(f['Name']) for f in og_files[1]]
         t_stamp = [pds.Timestamp(f['StartTime'][:10]) for f in og_files[1]]
         file_list = pds.Series(data=name_list, index=t_stamp)


### PR DESCRIPTION
# Description

Addresses the presence of an error being raised when no remote files are found, instead of an empty list.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import datetime as dt
import pysat
import pysatNASA

stime = dt.datetime(2024, 1, 1)
etime = dt.datetime(2024, 2, 1)
out_list = pysatNASA.instruments.methods.cdaweb.cdas_list_remote_files(tag='sdr-disk', inst_id='f18', start=stime, stop=etime, supported_tags=pysatNASA.instruments.dmsp_ssusi.download_tags, series_out=False)
out_series = pysatNASA.instruments.methods.cdaweb.cdas_list_remote_files(tag='sdr-disk', inst_id='f18', start=stime, stop=etime, supported_tags=pysatNASA.instruments.dmsp_ssusi.download_tags, series_out=True)
```

Note, there *is* data for this instrument and time, but CDAWeb cannot find it 😿 

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.10
* Any details about your local setup that are relevant: develop branch of pysat

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
