### PR TITLE
MAINT: ensure backward compat with pandas

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,13 +45,6 @@ jobs:
         pip install "cdflib<1.0"
         pip install -r requirements.txt
         pip install -r test_requirements.txt
-        cd ..
-        git clone https://github.com/pysat/pysat.git
-        cd pysat
-        git checkout pip_rc_install
-        python setup.py develop
-        cd ../pysatNASA
-        pip install .
 
     - name: Install NEP29 dependencies
       if: ${{ matrix.test_config == 'NEP29'}}

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -18,6 +18,7 @@ Adding new CDAWeb datasets should only require mininal user intervention.
 import datetime as dt
 import numpy as np
 import os
+from packaging.version import Version as pack_ver
 import pandas as pds
 import requests
 import tempfile
@@ -845,9 +846,15 @@ def list_remote_files(tag='', inst_id='', start=None, stop=None,
         if 'year' in search_dir['keys']:
             url_list = []
             if 'month' in search_dir['keys']:
+                # TODO(#242): remove if/else once support for older pandas is
+                # dropped.
+                if pack_ver(pds.__version__) >= pack_ver('2.2.0'):
+                    freq_key = 'ME'
+                else:
+                    freq_key = 'M'
                 search_times = pds.date_range(start,
                                               stop + pds.DateOffset(months=1),
-                                              freq='ME')
+                                              freq=freq_key)
                 for time in search_times:
                     subdir = format_dir.format(year=time.year, month=time.month)
                     url_list.append('/'.join((remote_url, subdir)))
@@ -857,9 +864,16 @@ def list_remote_files(tag='', inst_id='', start=None, stop=None,
                                                   + pds.DateOffset(days=1),
                                                   freq='D')
                 else:
+
+                    # TODO(#242): remove if/else once support for older pandas
+                    # is dropped.
+                    if pack_ver(pds.__version__) >= pack_ver('2.2.0'):
+                        freq_key = 'YE'
+                    else:
+                        freq_key = 'Y'
                     search_times = pds.date_range(start, stop
                                                   + pds.DateOffset(years=1),
-                                                  freq='YE')
+                                                  freq=freq_key)
                 for time in search_times:
                     doy = int(time.strftime('%j'))
                     subdir = format_dir.format(year=time.year, day=doy)


### PR DESCRIPTION
# Description

Addresses #242 (partial)

Ensures backward compatibility with pandas<2.2 and forward compatibility with pandas 3.0.

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via pytest

**Test Configuration**:
* Operating system: Sonoma 14.6.1
* Version number: Python 3.11.5
* pandas 2.1.4

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
