### PR TITLE
BUG/STY: update `_get_file` in download

### DIFF
--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -619,9 +619,9 @@ def _get_file(remote_file, data_path, fname, temp_path=None, zip_method=None):
         The method used to zip the file. Supports 'zip' and None.
         If None, downloads files directly. (default=None)
 
-    Warnings
-    --------
-    - Warns if temp_path not set when unzipping.
+    Raises
+    ------
+    ValueError if temp_path not specified for zip_method
 
     """
 

--- a/pysatNASA/instruments/methods/cdaweb.py
+++ b/pysatNASA/instruments/methods/cdaweb.py
@@ -542,6 +542,7 @@ def download(date_array, data_path, tag='', inst_id='', supported_tags=None,
                                      stop=date_array[-1])
 
     # Create temproary directory if files need to be unzipped.
+    # Use one temp dir for all files if needed.
     if 'zip_method' in inst_dict.keys():
         zip_method = inst_dict['zip_method']
         temp_dir = tempfile.TemporaryDirectory()
@@ -577,10 +578,11 @@ def download(date_array, data_path, tag='', inst_id='', supported_tags=None,
             with requests.get(remote_path) as req:
                 if req.status_code != 404:
                     if zip_method:
-                        get_file(req.content, data_path, fname,
-                                 temp_path=temp_dir.name, zip_method=zip_method)
+                        _get_file(req.content, data_path, fname,
+                                  temp_path=temp_dir.name,
+                                  zip_method=zip_method)
                     else:
-                        get_file(req.content, data_path, fname)
+                        _get_file(req.content, data_path, fname)
                     logger.info(''.join(('Successfully downloaded ',
                                          fname, '.')))
                 else:
@@ -599,7 +601,7 @@ def download(date_array, data_path, tag='', inst_id='', supported_tags=None,
     return
 
 
-def get_file(remote_file, data_path, fname, temp_path=None, zip_method=None):
+def _get_file(remote_file, data_path, fname, temp_path=None, zip_method=None):
     """Retrieve a file, unzipping if necessary.
 
     Parameters
@@ -617,11 +619,18 @@ def get_file(remote_file, data_path, fname, temp_path=None, zip_method=None):
         The method used to zip the file. Supports 'zip' and None.
         If None, downloads files directly. (default=None)
 
+    Warnings
+    --------
+    - Warns if temp_path not set when unzipping.
+
     """
 
     if zip_method:
         # Use a temporary location.
-        dl_fname = os.path.join(temp_path, fname)
+        if temp_path:
+            dl_fname = os.path.join(temp_path, fname)
+        else:
+            raise ValueError('Temp path needs to be set if unzipping')
     else:
         # Use the pysat data directory.
         dl_fname = os.path.join(data_path, fname)

--- a/pysatNASA/tests/test_methods_cdaweb.py
+++ b/pysatNASA/tests/test_methods_cdaweb.py
@@ -109,14 +109,22 @@ class TestCDAWeb(object):
         temp_dir = tempfile.TemporaryDirectory()
 
         with caplog.at_level(logging.WARNING, logger='pysat'):
-            cdw.get_file(req.content, '.', 'test.txt', temp_path=temp_dir.name,
-                         zip_method='badzip')
+            cdw._get_file(req.content, '.', 'test.txt', temp_path=temp_dir.name,
+                          zip_method='badzip')
         captured = caplog.text
 
         # Check for appropriate warning
         warn_msg = "not a recognized zip method"
         assert warn_msg in captured
 
+        return
+
+    def test_get_file_unzip_without_temp_path(self):
+        """Test that warning when cdf file does not have expected params."""
+
+        with pytest.raises(ValueError) as excinfo:
+            cdw._get_file('remote_file', 'fake_path', 'fname', zip_method='zip')
+        assert str(excinfo.value).find('Temp path needs') >= 0
         return
 
     @pytest.mark.parametrize("bad_key,bad_val,err_msg",


### PR DESCRIPTION
# Description

The `get_file` helper function was added to support downloading files that may need to be unzipped before local archival. This cleans up several issues identified in the RC. No update to changelog as this is captured by other changes in this version.
- Renames function to `_get_file` since this is not intended to be called directly by a user.
- Adds a ValueError if this should be invoked incorrectly.
- Adds test for the new error.

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

pytest pysatNASA/tests/test_methods_cdaweb.py

**Test Configuration**:
* Operating system: Mac OS X Sonoma
* Version number: Python 3.12

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
