### PR TITLE
MAINT: cycle ops tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,6 @@ jobs:
     - name: Install Operational dependencies
       if: ${{ matrix.test_config == 'Ops'}}
       run: |
-        sudo apt-get install libhdf5-serial-dev netcdf-bin libnetcdf-dev
         pip install --no-cache-dir numpy==${{ matrix.numpy_ver }}
         pip install --upgrade-strategy only-if-needed .[test]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,8 @@ jobs:
             numpy_ver: "1.24"
             os: ubuntu-latest
             test_config: "NEP29"
-          - python-version: "3.6.8"
-            numpy_ver: "1.19.5"
+          - python-version: "3.9"
+            numpy_ver: "1.23.5"
             os: "ubuntu-20.04"
             test_config: "Ops"
 
@@ -42,9 +42,7 @@ jobs:
       run: |
         sudo apt-get install libhdf5-serial-dev netcdf-bin libnetcdf-dev
         pip install --no-cache-dir numpy==${{ matrix.numpy_ver }}
-        pip install "cdflib<1.0"
-        pip install -r requirements.txt
-        pip install -r test_requirements.txt
+        pip install --upgrade-strategy only-if-needed .[test]
 
     - name: Install NEP29 dependencies
       if: ${{ matrix.test_config == 'NEP29'}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated standards for pandas, numpy, and pysat
   * Updated versions in GitHub Actions
   * Implement coveralls app in GitHub Actions
+  * Cycled Operational Environment testing
 
 ## [0.0.5] - 2023-06-27
 * New Instruments


### PR DESCRIPTION
# Description

Updates ops environment tests to use python 3.9. 

Code still supports 3.6, but there is no way of testing this. A partial list of things to do to update the code is documented in #245.

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

GitHub Actions

# Checklist:

- [rc] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
